### PR TITLE
Allow passing project_dir and libelixir path to libtrixi

### DIFF
--- a/examples/simple_trixi_controller.c
+++ b/examples/simple_trixi_controller.c
@@ -4,15 +4,22 @@
 
 int main ( int argc, char *argv[] ) {
 
-    // Initialize Trixi
-    trixi_initialize();
+    if ( argc < 2 ) {
+        fprintf(stderr, "error: missing arguments: PROJECT_DIR LIBELIXIR_PATH\n\n");
+        fprintf(stderr, "usage: %s PROJECT_DIR LIBELIXIR_PATH\n", argv[0]);
+        return 2;
+    } else if ( argc < 3 ) {
+        fprintf(stderr, "error: missing argument: LIBELIXIR_PATH\n\n");
+        fprintf(stderr, "usage: %s PROJECT_DIR LIBELIXIR_PATH\n", argv[0]);
+        return 2;
+    }
 
-    // An "elixir" file is required to configure the Trixi simulation
-    const char * elixir = "../../LibTrixi.jl/examples/libelixir_demo.jl";
+    // Initialize Trixi
+    trixi_initialize( argv[1] );
 
     // Setup the Trixi simulation
     // We get a handle to use subsequently
-    int handle = trixi_setup_simulation( elixir );
+    int handle = trixi_setup_simulation( argv[2] );
 
     // Get time step length
     printf("Current time step length: %f\n", trixi_calculate_dt(handle));

--- a/src/trixi.c
+++ b/src/trixi.c
@@ -17,13 +17,24 @@ static jl_value_t* checked_eval_string(const char* code, const char* func, const
  *
  *  \todo Path is still hard-coded
  */
-void trixi_initialize() {
+void trixi_initialize(const char * project_directory) {
 
     // Init Julia
     jl_init();
 
+    // Construct activation command
+    const char * activate = "using Pkg;\n"
+                            "Pkg.activate(\"%s\");\n"
+                            "Pkg.status();\n";
+    if ( strlen(activate) + strlen(project_directory) + 1 > 1024 ) {
+        fprintf(stderr, "error: buffer size not sufficient for activation command\n");
+        exit(1);
+    }
+    char buffer[1024];
+    snprintf(buffer, 1024, activate, project_directory);
+
     // Activate julia environment
-    checked_eval_string("using Pkg; Pkg.activate(\"../../LibTrixi.jl\"); Pkg.status()", LOC);
+    checked_eval_string(buffer, LOC);
 
     // Load LibTrixi module
     checked_eval_string("using LibTrixi;", LOC);

--- a/src/trixi.h
+++ b/src/trixi.h
@@ -1,7 +1,7 @@
 #ifndef TRIXI_H_
 #define TRIXI_H_
 
-void trixi_initialize();
+void trixi_initialize(const char * project_directory);
 int trixi_setup_simulation(const char * elixir);
 double trixi_calculate_dt(int handle);
 int trixi_is_finished(int handle);


### PR DESCRIPTION
If inside a `libtrixi/build` directory and after compiling libtrixi and the examples, this PR allows one to run a simulation with
```shell
examples/simple_trixi_controller ../LibTrixi.jl/ ../LibTrixi.jl/examples/libelixir_demo.jl
```
giving output similar to this
```
  Activating project at `/mnt/ssd/home/mschlott/hackathon/libtrixi/LibTrixi.jl`
Project LibTrixi v0.1.0
Status `/mnt/ssd/home/mschlott/hackathon/libtrixi/LibTrixi.jl/Project.toml` (empty project)
Module LibTrixi.jl loaded
Simulation state initialized
Current time step length: 0.300000
Current time: 0.3
Current time: 0.6
Current time: 0.8999999999999999
Current time: 1.0
Final time reached
Simulation state finalized
libtrixi: finalize
```

I created this as a PR into #14, feel free if you're happy with this.