### PR TITLE
Add Fortran example to match C example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
         if: ${{ matrix.test_type == 'regular' }}
         run: |
           cd run
-          ../build/examples/simple_trixi_controller . libelixir_demo.jl
+          ../build/examples/simple_trixi_controller_c . libelixir_demo.jl
+          ../build/examples/simple_trixi_controller_f . libelixir_demo.jl
       - name: Run memory checks with Valgrind
         if: ${{ matrix.test_type == 'valgrind' }}
         run: |
@@ -120,7 +121,8 @@ jobs:
         run: |
           cd run
           lcov --directory ../build --zerocounters
-          ../build/examples/simple_trixi_controller . libelixir_demo.jl
+          ../build/examples/simple_trixi_controller_c . libelixir_demo.jl
+          ../build/examples/simple_trixi_controller_f . libelixir_demo.jl
           lcov --directory ../build  --capture --output-file lcov.info
       - uses: codecov/codecov-action@v3
         if: ${{ matrix.test_type == 'coverage' }}

--- a/README.md
+++ b/README.md
@@ -83,14 +83,37 @@ the `project_directory` argument to `trixi_initialize`.
 
 ### Testing
 
-Go to the repository root directory and run a simple demonstrator:
+Go to the repository root directory and run a simple demonstrator,
 ```shell
 cd ..
 JULIA_DEPOT_PATH=$PWD/libtrixi-julia/JULIA_DEPOT_LIBTRIXI \
-    build/examples/simple_trixi_controller \
+    build/examples/simple_trixi_controller_c \
     $PWD/libtrixi-julia \
     LibTrixi.jl/examples/libelixir_demo.jl
 ```
+which should give you an output similar to this:
+```
+  Activating project at `~/hackathon/libtrixi/libtrixi-julia`
+Status `/mnt/ssd/home/mschlott/hackathon/libtrixi/libtrixi-julia/Project.toml`
+  [7e097bd5] LibTrixi v0.1.0 `../LibTrixi.jl`
+  [3da0fdf6] MPIPreferences v0.1.8
+Module LibTrixi.jl loaded
+Simulation state initialized
+Current time step length: 0.300000
+Current time: 0.3
+Current time: 0.6
+Current time: 0.8999999999999999
+Current time: 1.0
+Final time reached
+Simulation state finalized
+libtrixi: finalize
+```
+
+If you change the executable name from `simple_trixi_controller_c` to
+`simple_trixi_controller_f`, you will get a near identical output. The corresponding source
+files `simple_trixi_controller.c` and `simple_trixi_controller.f90` give you an idea on how
+to use the C and Fortran APIs of libtrixi, and can be found in the
+[`examples/`](examples/) folder.
 
 ## Authors
 Libtrixi was initiated by

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -87,7 +87,7 @@ Go to the repository root directory and run a simple demonstrator,
 ```shell
 cd ..
 JULIA_DEPOT_PATH=$PWD/libtrixi-julia/JULIA_DEPOT_LIBTRIXI \
-    build/examples/simple_trixi_controller \
+    build/examples/simple_trixi_controller_c \
     $PWD/libtrixi-julia \
     LibTrixi.jl/examples/libelixir_demo.jl
 ```
@@ -108,6 +108,12 @@ Final time reached
 Simulation state finalized
 libtrixi: finalize
 ```
+
+If you change the executable name from `simple_trixi_controller_c` to
+`simple_trixi_controller_f`, you will get a near identical output. The corresponding source
+files `simple_trixi_controller.c` and `simple_trixi_controller.f90` give you an idea on how
+to use the C and Fortran APIs of libtrixi, and can be found in the
+[`examples/`](https://github.com/trixi-framework/libtrixi/tree/main/examples) folder.
 
 ## Authors
 Libtrixi was initiated by

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,15 +17,33 @@ install( TARGETS fortran_hello_world )
 
 
 #
-# Simple Trixi Controller
+# Simple Trixi Controller (C version)
 #
-add_executable(simple_trixi_controller simple_trixi_controller.c)
+add_executable(simple_trixi_controller_c simple_trixi_controller.c)
 
-target_link_libraries(simple_trixi_controller PRIVATE ${PROJECT_NAME})
+target_link_libraries(simple_trixi_controller_c PRIVATE ${PROJECT_NAME})
 
-target_include_directories(simple_trixi_controller PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(simple_trixi_controller_c PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # Set runtime path for installed binaries
-set_target_properties( simple_trixi_controller PROPERTIES INSTALL_RPATH "../lib")
+set_target_properties( simple_trixi_controller_c PROPERTIES INSTALL_RPATH "../lib")
 
-install( TARGETS simple_trixi_controller )
+install( TARGETS simple_trixi_controller_c )
+
+
+
+#
+# Simple Trixi Controller (Fortran version)
+#
+add_executable(simple_trixi_controller_f simple_trixi_controller.f90)
+
+target_link_directories(simple_trixi_controller_f PRIVATE ${CMAKE_BINARY_DIR})
+
+target_link_libraries(simple_trixi_controller_f PRIVATE ${PROJECT_NAME})
+
+target_include_directories(simple_trixi_controller_f PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+# Set runtime path for installed binaries
+set_target_properties( simple_trixi_controller_f PROPERTIES INSTALL_RPATH "../lib")
+
+install( TARGETS simple_trixi_controller_f )

--- a/examples/fortran_hello_world.f90
+++ b/examples/fortran_hello_world.f90
@@ -1,5 +1,6 @@
 program fortran_hello_world
   use LibTrixi
+  use, intrinsic :: iso_c_binding, only: c_null_char
 
   implicit none
 
@@ -13,7 +14,7 @@ program fortran_hello_world
   call MPI_Init(ierror)
 
   ! Initialize Julia and Trixi
-  call trixi_initialize()
+  call trixi_initialize("../libtrixi-julia" // c_null_char)
 
   ! Say hello to julia
   call julia_eval_string('println("fortran:  Hello julia!")')

--- a/examples/simple_trixi_controller.c
+++ b/examples/simple_trixi_controller.c
@@ -5,11 +5,11 @@
 int main ( int argc, char *argv[] ) {
 
     if ( argc < 2 ) {
-        fprintf(stderr, "error: missing arguments: PROJECT_DIR LIBELIXIR_PATH\n\n");
+        fprintf(stderr, "ERROR: missing arguments: PROJECT_DIR LIBELIXIR_PATH\n\n");
         fprintf(stderr, "usage: %s PROJECT_DIR LIBELIXIR_PATH\n", argv[0]);
         return 2;
     } else if ( argc < 3 ) {
-        fprintf(stderr, "error: missing argument: LIBELIXIR_PATH\n\n");
+        fprintf(stderr, "ERROR: missing argument: LIBELIXIR_PATH\n\n");
         fprintf(stderr, "usage: %s PROJECT_DIR LIBELIXIR_PATH\n", argv[0]);
         return 2;
     }

--- a/examples/simple_trixi_controller.f90
+++ b/examples/simple_trixi_controller.f90
@@ -1,0 +1,48 @@
+program simple_trixi_controller_f
+  use LibTrixi
+  use, intrinsic :: iso_fortran_env, only: error_unit
+  use, intrinsic :: iso_c_binding, only: c_int, c_null_char
+
+  implicit none
+
+  integer(c_int) :: handle
+  character(len=256) :: argument
+
+  if (command_argument_count() < 1) then
+    call get_command_argument(0, argument)
+    write(error_unit, '(a)') "ERROR: missing arguments: PROJECT_DIR LIBELIXIR_PATH"
+    write(error_unit, '(a)') ""
+    write(error_unit, '(3a)') "usage: ", trim(argument), " PROJECT_DIR LIBELIXIR_PATH"
+    stop 1
+  else if (command_argument_count() < 2) then
+    call get_command_argument(0, argument)
+    write(error_unit, '(a)') "ERROR: missing argument: LIBELIXIR_PATH"
+    write(error_unit, '(a)') ""
+    write(error_unit, '(3a)') "usage: ", trim(argument), " PROJECT_DIR LIBELIXIR_PATH"
+    stop 1
+  end if
+
+
+  ! Initialize Trixi
+  call get_command_argument(1, argument)
+  call trixi_initialize(trim(argument) // c_null_char)
+
+  ! Set up the Trixi simulation
+  ! We get a handle to use subsequently
+  call get_command_argument(2, argument)
+  handle = trixi_initialize_simulation(trim(argument) // c_null_char)
+
+  ! Get time step length
+  write(*, '(a, e14.8)') "Current time step length: ", trixi_calculate_dt(handle)
+
+  ! Main loop
+  do while ( trixi_is_finished(handle) == 0 )
+    call trixi_step(handle)
+  end do
+
+  ! Finalize Trixi simulation
+  call trixi_finalize_simulation(handle)
+
+  ! Finalize Trixi
+  call trixi_finalize()
+end program

--- a/src/trixi.f90
+++ b/src/trixi.f90
@@ -2,7 +2,34 @@ module LibTrixi
   implicit none
 
   interface
-    subroutine trixi_initialize() bind(c)
+    subroutine trixi_initialize(project_directory) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_char
+      character(kind=c_char), intent(in) :: project_directory(*)
+    end subroutine
+
+    integer(c_int) function trixi_initialize_simulation(libelixir) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_char, c_int
+      character(kind=c_char), intent(in) :: libelixir(*)
+    end function
+
+    real(c_double) function trixi_calculate_dt(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int, c_double
+      integer(c_int), value, intent(in) :: handle
+    end function
+
+    integer(c_int) function trixi_is_finished(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int
+      integer(c_int), value, intent(in) :: handle
+    end function
+
+    subroutine trixi_step(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int
+      integer(c_int), value, intent(in) :: handle
+    end subroutine
+
+    subroutine trixi_finalize_simulation(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int
+      integer(c_int), value, intent(in) :: handle
     end subroutine
 
     subroutine trixi_finalize() bind(c)
@@ -10,7 +37,7 @@ module LibTrixi
 
     subroutine julia_eval_string(code) bind(c)
       use, intrinsic :: iso_c_binding, only: c_char
-      character(kind=c_char) :: code(*)
+      character(kind=c_char), intent(in) :: code(*)
     end subroutine
   end interface
 end module


### PR DESCRIPTION
Resolves #15 (I believe).

This PR creates a `simple_trixi_controller.f90` that mimics the C version `simple_trixi_controller.c` nearly identically. It also makes the Fortran interface match the current C interface again.

C version:
```
$ examples/simple_trixi_controller_c ../run ../run/libelixir_demo.jl
  Activating project at `/mnt/ssd/home/mschlott/hackathon/libtrixi/run`
Status `/mnt/ssd/home/mschlott/hackathon/libtrixi/run/Project.toml`
  [7e097bd5] LibTrixi v0.1.0 `../LibTrixi.jl`
Module LibTrixi.jl loaded
Simulation state initialized
Current time step length: 0.300000
Current time: 0.3
Current time: 0.6
Current time: 0.8999999999999999
Current time: 1.0
Final time reached
Simulation state finalized
libtrixi: finalize
```

Fortran version:
```
$ examples/simple_trixi_controller_f ../run ../run/libelixir_demo.jl
  Activating project at `/mnt/ssd/home/mschlott/hackathon/libtrixi/run`
Status `/mnt/ssd/home/mschlott/hackathon/libtrixi/run/Project.toml`
  [7e097bd5] LibTrixi v0.1.0 `../LibTrixi.jl`
Module LibTrixi.jl loaded
Simulation state initialized
Current time step length: 0.30000000E+00
Current time: 0.3
Current time: 0.6
Current time: 0.8999999999999999
Current time: 1.0
Final time reached
Simulation state finalized
libtrixi: finalize
```

Note that the executables are renamed to `simple_trixi_controller_c` and `simple_trixi_controller_f` respectively.