### PR TITLE
Allow one to use `JULIA_DEFINE_FAST_TLS` by linking to `libtrixi_tls.o`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           cd build
           make install
       - name: Test building with an external Makefile
+        if: ${{ matrix.test_type == 'regular' }}
         run: |
           cd examples
           make -f MakefileExternal LIBTRIXI_PREFIX=$PWD/../install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
-        default: false
+        default: "false"
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ libtrixi.so*
 
 # Documenter
 docs/build
+
+# VS Code
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ target_link_libraries( ${PROJECT_NAME} PRIVATE ${JULIA_LIBRARY} ${MPI_C_LIB_NAME
 target_compile_options( ${PROJECT_NAME} PUBLIC "-fPIC" )
 
 
+# Add auxiliary *object* library to support fast thread-local storage (TLS)
+add_library ( ${PROJECT_NAME}_tls OBJECT
+    src/trixi_tls.c
+)
+target_include_directories( ${PROJECT_NAME}_tls PRIVATE ${JULIA_INCLUDE_DIRS} )
 
 # Add examples
 add_subdirectory( examples )
@@ -68,5 +73,6 @@ add_subdirectory( examples )
 # Install configuration
 install( TARGETS ${PROJECT_NAME} )
 install( FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/libtrixi.mod TYPE INCLUDE)
+install( FILES $<TARGET_OBJECTS:${PROJECT_NAME}_tls> TYPE LIB RENAME lib${PROJECT_NAME}_tls.o )
 install( DIRECTORY LibTrixi.jl DESTINATION share/libtrixi )
 install( PROGRAMS utils/libtrixi-init-julia TYPE BIN )

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ to build `simple_trixi_controller_f`.
 
 Note: On Linux and FreeBSD systems (i.e., *not* on macOS or Windows), Julia may internally
 use a faster implementation for thread-local storage (TLS), which is used whenever Julia
-functions such task management, garbage colletion etc. are used in a multithreaded
+functions such task management, garbage collection etc. are used in a multithreaded
 context, or when they are themselves multithreaded. To activate the fast TLS in your
 program, you need to add the file `$LIBTRIXI_PREFIX/lib/libtrixi_tls.o` to the list of files
 that are linked with your main program. See `MakefileExternal` for an example of how to do

--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ make -f MakefileExternal LIBTRIXI_PREFIX=path/to/libtrixi/prefix
 ```
 to build `simple_trixi_controller_f`.
 
+Note: On Linux and FreeBSD systems (i.e., *not* on macOS or Windows), Julia may internally
+use a faster implementation for thread-local storage (TLS), which is used whenever Julia
+functions such task management, garbage colletion etc. are used in a multithreaded
+context, or when they are themselves multithreaded. To activate the fast TLS in your
+program, you need to add the file `$LIBTRIXI_PREFIX/lib/libtrixi_tls.o` to the list of files
+that are linked with your main program. See `MakefileExternal` for an example of how to do
+this. If you skip this step, everything will work as usual, but some things might run
+slightly slower.
+
 
 ## Authors
 Libtrixi was initiated by

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -235,7 +235,7 @@ to build `simple_trixi_controller_f`.
 
 Note: On Linux and FreeBSD systems (i.e., *not* on macOS or Windows), Julia may internally
 use a faster implementation for thread-local storage (TLS), which is used whenever Julia
-functions such task management, garbage colletion etc. are used in a multithreaded
+functions such task management, garbage collection etc. are used in a multithreaded
 context, or when they are themselves multithreaded. To activate the fast TLS in your
 program, you need to add the file `$LIBTRIXI_PREFIX/lib/libtrixi_tls.o` to the list of files
 that are linked with your main program. See `MakefileExternal` for an example of how to do

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -233,6 +233,15 @@ make -f MakefileExternal LIBTRIXI_PREFIX=path/to/libtrixi/prefix
 ```
 to build `simple_trixi_controller_f`.
 
+Note: On Linux and FreeBSD systems (i.e., *not* on macOS or Windows), Julia may internally
+use a faster implementation for thread-local storage (TLS), which is used whenever Julia
+functions such task management, garbage colletion etc. are used in a multithreaded
+context, or when they are themselves multithreaded. To activate the fast TLS in your
+program, you need to add the file `$LIBTRIXI_PREFIX/lib/libtrixi_tls.o` to the list of files
+that are linked with your main program. See `MakefileExternal` for an example of how to do
+this. If you skip this step, everything will work as usual, but some things might run
+slightly slower.
+
 
 ## Authors
 Libtrixi was initiated by

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(simple_trixi_controller_c simple_trixi_controller.c)
 
 target_link_libraries(
   simple_trixi_controller_c
-  PRIVATE ${MPI_C_LIBRARIES} ${PROJECT_NAME}
+  PRIVATE ${MPI_C_LIBRARIES} ${PROJECT_NAME} ${PROJECT_NAME}_tls
 )
 
 target_include_directories(
@@ -29,7 +29,7 @@ target_link_directories(simple_trixi_controller_f PRIVATE ${CMAKE_BINARY_DIR})
 
 target_link_libraries(
   simple_trixi_controller_f
-  PRIVATE ${MPI_Fortran_LIBRARIES} ${PROJECT_NAME}
+  PRIVATE ${MPI_Fortran_LIBRARIES} ${PROJECT_NAME}  ${PROJECT_NAME}_tls
 )
 
 target_include_directories(

--- a/examples/MakefileExternal
+++ b/examples/MakefileExternal
@@ -7,4 +7,4 @@ libdir := $(LIBTRIXI_PREFIX)/lib
 incdir := $(LIBTRIXI_PREFIX)/include
 
 simple_trixi_controller_f: simple_trixi_controller.f90
-	$(FC) $< -o $@ -I$(incdir) -L$(libdir) -Wl,-rpath,$(LIBTRIXI_LIBRARY_DIR) -ltrixi
+	$(FC) $< -o $@ -I$(incdir) -L$(libdir) -Wl,-rpath,$(libdir) -ltrixi $(libdir)/libtrixi_tls.o

--- a/src/trixi.c
+++ b/src/trixi.c
@@ -3,9 +3,6 @@
 #include <string.h>
 #include <julia.h>
 
-// TODO
-// JULIA_DEFINE_FAST_TLS // only define this once, in an executable (not in a shared library) if you want fast code.
-
 #include "trixi.h"
 
 

--- a/src/trixi_tls.c
+++ b/src/trixi_tls.c
@@ -1,0 +1,3 @@
+#include <julia.h>
+
+JULIA_DEFINE_FAST_TLS


### PR DESCRIPTION
Resolves #22.