### PR TITLE
Provide convenience methods for Fortran interface

### DIFF
--- a/examples/simple_trixi_controller.f90
+++ b/examples/simple_trixi_controller.f90
@@ -25,18 +25,21 @@ program simple_trixi_controller_f
 
   ! Initialize Trixi
   call get_command_argument(1, argument)
-  call trixi_initialize(trim(argument) // c_null_char)
+  call trixi_initialize(argument)
 
   ! Set up the Trixi simulation
   ! We get a handle to use subsequently
   call get_command_argument(2, argument)
-  handle = trixi_initialize_simulation(trim(argument) // c_null_char)
+  handle = trixi_initialize_simulation(argument)
 
   ! Get time step length
   write(*, '(a, e14.8)') "Current time step length: ", trixi_calculate_dt(handle)
 
   ! Main loop
-  do while ( trixi_is_finished(handle) == 0 )
+  do
+    ! Exit loop once simulation is completed
+    if ( trixi_is_finished(handle) ) exit
+
     call trixi_step(handle)
   end do
 

--- a/src/trixi.f90
+++ b/src/trixi.f90
@@ -2,14 +2,14 @@ module LibTrixi
   implicit none
 
   interface
-    subroutine trixi_initialize(project_directory) bind(c)
+    subroutine trixi_initialize_c(project_directory) bind(c, name='trixi_initialize')
       use, intrinsic :: iso_c_binding, only: c_char
-      character(kind=c_char), intent(in) :: project_directory(*)
+      character(kind=c_char), dimension(*), intent(in) :: project_directory
     end subroutine
 
-    integer(c_int) function trixi_initialize_simulation(libelixir) bind(c)
+    integer(c_int) function trixi_initialize_simulation_c(libelixir) bind(c, name='trixi_initialize_simulation')
       use, intrinsic :: iso_c_binding, only: c_char, c_int
-      character(kind=c_char), intent(in) :: libelixir(*)
+      character(kind=c_char), dimension(*), intent(in) :: libelixir
     end function
 
     real(c_double) function trixi_calculate_dt(handle) bind(c)
@@ -17,7 +17,7 @@ module LibTrixi
       integer(c_int), value, intent(in) :: handle
     end function
 
-    integer(c_int) function trixi_is_finished(handle) bind(c)
+    integer(c_int) function trixi_is_finished_c(handle) bind(c, name='trixi_is_finished')
       use, intrinsic :: iso_c_binding, only: c_int
       integer(c_int), value, intent(in) :: handle
     end function
@@ -40,4 +40,28 @@ module LibTrixi
       character(kind=c_char), intent(in) :: code(*)
     end subroutine
   end interface
+
+  contains
+
+  logical function trixi_is_finished(handle)
+    use, intrinsic :: iso_c_binding, only: c_int
+    integer(c_int), intent(in) :: handle
+
+    trixi_is_finished = trixi_is_finished_c(handle) == 1
+  end function
+
+  subroutine trixi_initialize(project_directory)
+    use, intrinsic :: iso_c_binding, only: c_null_char
+    character(len=*), intent(in) :: project_directory
+
+    call trixi_initialize_c(trim(adjustl(project_directory)) // c_null_char)
+  end subroutine
+
+  integer(c_int) function trixi_initialize_simulation(libelixir)
+    use, intrinsic :: iso_c_binding, only: c_int, c_null_char
+    character(len=*), intent(in) :: libelixir
+
+    trixi_initialize_simulation = trixi_initialize_simulation_c(trim(adjustl(libelixir)) // c_null_char)
+  end function
+
 end module

--- a/src/trixi.f90
+++ b/src/trixi.f90
@@ -35,9 +35,9 @@ module LibTrixi
     subroutine trixi_finalize() bind(c)
     end subroutine
 
-    subroutine julia_eval_string(code) bind(c)
+    subroutine julia_eval_string_c(code) bind(c, name='julia_eval_string')
       use, intrinsic :: iso_c_binding, only: c_char
-      character(kind=c_char), intent(in) :: code(*)
+      character(kind=c_char), dimension(*), intent(in) :: code
     end subroutine
   end interface
 
@@ -64,4 +64,10 @@ module LibTrixi
     trixi_initialize_simulation = trixi_initialize_simulation_c(trim(adjustl(libelixir)) // c_null_char)
   end function
 
+  subroutine julia_eval_string(code)
+    use, intrinsic :: iso_c_binding, only: c_null_char
+    character(len=*), intent(in) :: code
+
+    call julia_eval_string_c(trim(adjustl(code)) // c_null_char)
+  end subroutine
 end module


### PR DESCRIPTION
I noticed in MESSy that the current Fortran bindings might be hard to use for people not familiar with C-style programming or calling C functions from Fortran. Specifically, the use of `trim(adjustl(string)) // c_null_char` for string arguments such as
```fortran
CALL trixi_initialize(TRIM(ADJUSTL(trixi_runtime_path))//char(0))
```
([source](https://gitlab.dkrz.de/MESSy/MESSy/-/blob/52a431eaa5001eb88365d375f5b1d52503dd7ae2/messy/smcl/messy_trixi.f90#L68)) or the awkward comparison of boolean-intent return values against `0`/`1` such as
```fortran
IF (trixi_is_finished(handle) .ne. 0) THEN
```
([source](https://gitlab.dkrz.de/MESSy/MESSy/-/blob/52a431eaa5001eb88365d375f5b1d52503dd7ae2/messy/smcl/messy_trixi.f90#L105)).

This PR changes the Fortran bindings to our C API such that all subroutines/functions that expect a string argument can now be supplied a regular Fortran string (i.e., a scalar of type `character`) and do the necessary conversions (trimming, appending `null`) internally. Similarly, functions expecting/returning a boolean value in the form of an integer (C-style booleans) now will work with Fortran `logical`s. Thus, the above two snippets can now be written as
```fortran
CALL trixi_initialize(trixi_runtime_path)
```
and
```fortran
IF (trixi_is_finished(handle)) THEN
```
For full control/as a fallback, the original functions/subroutines are available with a `_c` prefix, e.g., the Fortran subroutine `julia_eval_string_c` will directly call the C function `julia_eval_string`, while the Fortran subroutine `julia_eval_string` will exhibit the convenience behavior described above an internally call `julia_eval_string_c`.

Please let me know what you think about this @bgeihe @KerstinHartung, since I am not sure if this makes it easier to use libtrixi for Fortran or is just another source of confusion. (Note that we do not have any documentation of the official API yet, so please do not hold this against this PR 😬)