### PR TITLE
Simplify usage by allow to omit the JULIA_DEPOT_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ cd libtrixi-julia
     --p4est-library <p4est_install_directory>/lib/libp4est.so
     <install_directory>
 ```
-
 Use `libtrixi-init-julia -h` to get help.
-When running a program that uses libtrixi, make sure to set up the `JULIA_DEPOT_PATH`
-environment variable to point to the `<julia-depot>` folder reported. In your code, pass
-the path to the `libtrixi-julia` directory to `trixi_initialize`, see the code of the
-examples.
+
+In your code, pass the path to the `libtrixi-julia` directory to `trixi_initialize`,
+see the code of the examples. If you did not modify the default value for the Julia depot
+when calling `libtrixi-init-julia`, libtrixi will find it automatically.
+Otherwise, when running a program that uses libtrixi, you need to make sure to set the
+`JULIA_DEPOT_PATH` environment variable to point to the `<julia-depot>` folder reported. 
 
 ### Testing
 
@@ -97,7 +98,6 @@ Go to some directory from where you want to run a Trixi simulation.
 
 ```shell
 LIBTRIXI_DEBUG=all \
-JULIA_DEPOT_PATH=<julia-depot> \
     <install_directory>/bin/simple_trixi_controller_c \
     <libtrixi-julia_directory> \
     <install_directory>/share/libtrixi/LibTrixi.jl/examples/libelixir_tree1d_dgsem_advection_basic.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,12 +86,13 @@ cd libtrixi-julia
     --p4est-library <p4est_install_directory>/lib/libp4est.so
     <install_directory>
 ```
-
 Use `libtrixi-init-julia -h` to get help.
-When running a program that uses libtrixi, make sure to set up the `JULIA_DEPOT_PATH`
-environment variable to point to the `<julia-depot>` folder reported. In your code, pass
-the path to the `libtrixi-julia` directory to `trixi_initialize`, see the code of the
-examples.
+
+In your code, pass the path to the `libtrixi-julia` directory to `trixi_initialize`,
+see the code of the examples. If you did not modify the default value for the Julia depot
+when calling `libtrixi-init-julia`, libtrixi will find it automatically.
+Otherwise, when running a program that uses libtrixi, you need to make sure to set the
+`JULIA_DEPOT_PATH` environment variable to point to the `<julia-depot>` folder reported. 
 
 ### Testing
 
@@ -99,7 +100,6 @@ Go to some directory from where you want to run a Trixi simulation.
 
 ```shell
 LIBTRIXI_DEBUG=all \
-JULIA_DEPOT_PATH=<julia-depot> \
     <install_directory>/bin/simple_trixi_controller_c \
     <libtrixi-julia_directory> \
     <install_directory>/share/libtrixi/LibTrixi.jl/examples/libelixir_tree1d_dgsem_advection_basic.jl

--- a/examples/simple_trixi_controller.c
+++ b/examples/simple_trixi_controller.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <mpi.h>
 
 #include <trixi.h>
@@ -51,7 +52,7 @@ int main ( int argc, char *argv[] ) {
 
     // Initialize Trixi
     printf("\n*** Trixi controller ***   Initialize Trixi\n");
-    trixi_initialize( argv[1] );
+    trixi_initialize( argv[1], NULL );
 
     // Set up the Trixi simulation
     // We get a handle to use subsequently

--- a/src/trixi.f90
+++ b/src/trixi.f90
@@ -3,7 +3,7 @@ module LibTrixi
 
   interface
     subroutine trixi_initialize_c(project_directory, depot_path) bind(c, name='trixi_initialize')
-      use, intrinsic :: iso_c_binding, only: c_char, c_int
+      use, intrinsic :: iso_c_binding, only: c_char
       character(kind=c_char), dimension(*), intent(in) :: project_directory
       character(kind=c_char), dimension(*), intent(in), optional :: depot_path
     end subroutine

--- a/src/trixi.f90
+++ b/src/trixi.f90
@@ -2,9 +2,10 @@ module LibTrixi
   implicit none
 
   interface
-    subroutine trixi_initialize_c(project_directory) bind(c, name='trixi_initialize')
-      use, intrinsic :: iso_c_binding, only: c_char
+    subroutine trixi_initialize_c(project_directory, depot_path) bind(c, name='trixi_initialize')
+      use, intrinsic :: iso_c_binding, only: c_char, c_int
       character(kind=c_char), dimension(*), intent(in) :: project_directory
+      character(kind=c_char), dimension(*), intent(in), optional :: depot_path
     end subroutine
 
     integer(c_int) function trixi_initialize_simulation_c(libelixir) bind(c, name='trixi_initialize_simulation')
@@ -50,11 +51,17 @@ module LibTrixi
     trixi_is_finished = trixi_is_finished_c(handle) == 1
   end function
 
-  subroutine trixi_initialize(project_directory)
+  subroutine trixi_initialize(project_directory, depot_path)
     use, intrinsic :: iso_c_binding, only: c_null_char
     character(len=*), intent(in) :: project_directory
+    character(len=*), intent(in), optional :: depot_path
 
-    call trixi_initialize_c(trim(adjustl(project_directory)) // c_null_char)
+    if (present(depot_path)) then
+      call trixi_initialize_c(trim(adjustl(project_directory)) // c_null_char, &
+                              trim(adjustl(depot_path)) // c_null_char)
+    else
+      call trixi_initialize_c(trim(adjustl(project_directory)) // c_null_char)
+    end if
   end subroutine
 
   integer(c_int) function trixi_initialize_simulation(libelixir)

--- a/src/trixi.h
+++ b/src/trixi.h
@@ -1,7 +1,7 @@
 #ifndef TRIXI_H_
 #define TRIXI_H_
 
-void trixi_initialize(const char * project_directory);
+void trixi_initialize(const char * project_directory, const char * depot_path);
 int trixi_initialize_simulation(const char * libelixir);
 double trixi_calculate_dt(int handle);
 int trixi_is_finished(int handle);

--- a/utils/libtrixi-init-julia
+++ b/utils/libtrixi-init-julia
@@ -83,6 +83,8 @@ if [ -z "$LIBTRIXI_JULIA_EXEC" ]; then
   LIBTRIXI_JULIA_EXEC=julia
 fi
 if [ -z "$LIBTRIXI_JULIA_DEPOT" ]; then
+  # OBS! If you change this value here, you should also update the default value for
+  # `default_depot_path` in `src/trixi.c` accordingly
   LIBTRIXI_JULIA_DEPOT=julia-depot
 fi
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Before, one always had to start programs with `JULIA_DEPOT_PATH=path myprog` when running a program `myprog` that links to `libtrixi`. With this PR, setting `JULIA_DEPOT_PATH` becomes unnecessary as long as the default depot location used by by `utils/libtrixi-init-julia` is left untouched.

This should help to avoid user errors in case they forget to set the Julia depot path appropriately. If a `JULIA_DEPOT_PATH` environment variable is set, it will honored, thus the user can still provide non-standard locations via the environment. Overriding the default is also possible by calling `trixi_initialize` with a second, non-null argument.