### PR TITLE
Add `-Wall -Wextra -Werror` to compilation flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries( ${PROJECT_NAME} PRIVATE ${JULIA_LIBRARY} MPI::MPI_C )
 
 # Set appropriate compile flags
 target_compile_options( ${PROJECT_NAME} PUBLIC "-fPIC" )
+target_compile_options( ${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror)
 
 # Pass version information
 target_compile_definitions( ${PROJECT_NAME} PRIVATE

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -40,6 +40,9 @@ foreach ( EXAMPLE ${EXAMPLES} )
         PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
     )
 
+    # enable warnings
+    target_compile_options( ${TARGET_NAME} PRIVATE -Wall -Wextra -Werror )
+
     # add to installation
     install( TARGETS ${TARGET_NAME} )
 


### PR DESCRIPTION
Resolves #70.

Note that we cannot add `-Wpedantic` since we convert the return value of `jl_unbox_voidpointer` to a function pointer when we want to call Julia functions from C. While this does not present an issue on x64 platforms, it is technically undefined behavior (C only explicitly allows object pointer to object pointer conversion, and function pointer to function pointer conversion). There does not seem to be a sane way around this at the moment, but since it is not presenting a problem either, I think it is ok for now.