### PR TITLE
Switch to monthly dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Similar to what we have done in other repos, this should keep the noise created by the alerts in check.