### PR TITLE
Safeguard `trixi_initialize`/`trixi_finalize` against erroneous use

### DIFF
--- a/src/api.f90
+++ b/src/api.f90
@@ -25,6 +25,10 @@ module LibTrixi
     !! `JULIA_DEPOT_PATH` is already set, do not touch it. Otherwise, set
     !! `JULIA_DEPOT_PATH` to `project_directory` + `default_depot_path`.
     !!
+    !! This routine must be called before most other libtrixi routines can be used.
+    !! Libtrixi maybe only be initialized once; subsequent calls to `trixi_initialize` are
+    !! erroneous.
+    !!
     !! @param[in]  project_directory  Path to project directory (C char pointer)
     !! @param[in]  depot_path         Path to Julia depot path (optional, C char pointer)
     !!
@@ -40,6 +44,10 @@ module LibTrixi
     !! @fn LibTrixi::trixi_finalize::trixi_finalize()
     !!
     !! @brief Finalize Julia runtime environment.
+    !!
+    !! Clean up internal states. This routine should be executed near the end of the
+    !! process' lifetime. After the call to `trixi_finalize`, no other libtrixi routines may
+    !! be called anymore, including `trixi_finalize` itself.
     !!
     !! @see @ref trixi_finalize_api_c "trixi_finalize (C API)"
     subroutine trixi_finalize() bind(c)

--- a/test/interface_c.cpp
+++ b/test/interface_c.cpp
@@ -68,7 +68,7 @@ TEST(CInterfaceTest, VersionInfo) {
     EXPECT_NE(version_string_julia_ext.find("StartUpDG"), std::string::npos);
 
     // Finalize libtrixi
-    trixi_initialize( julia_project_path, NULL );
+    trixi_finalize();
 }
 
 
@@ -86,7 +86,7 @@ TEST(CInterfaceTest, JuliaCode) {
     EXPECT_DEATH(trixi_eval_julia("printline(\"Hello from Julia!\")"), "");
 
     // Finalize libtrixi
-    trixi_initialize( julia_project_path, NULL );
+    trixi_finalize();
 }
 
 
@@ -106,7 +106,7 @@ TEST(CInterfaceTest, FunctionPointers) {
     EXPECT_DEATH(store_function_pointers(num_fptrs, fptr_names, fptrs), "");
 
     // Finalize libtrixi
-    trixi_initialize( julia_project_path, NULL );
+    trixi_finalize();
 }
 
 


### PR DESCRIPTION
Resolves #88.