### PR TITLE
Miscellaneous CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Show Julia version information
         run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
 
-      - name: Install dependencies available as Ubuntu packages
+      - name: Install dependencies available with `apt-get`
         # - MPI
         # - HDF5
         # - Google Test
@@ -174,13 +174,13 @@ jobs:
         run: |
           cd libtrixi-julia
           set +e  # disable early exit on non-zero exit code
-          for command in "../build/examples/simple_trixi_controller_c" \
+          for command in "../build/examples/simple_trixi_controller_c"   \
                          "../build/examples/simple_trixi_controller_c ." \
-                         "../build/examples/simple_trixi_controller_f" \
+                         "../build/examples/simple_trixi_controller_f"   \
                          "../build/examples/simple_trixi_controller_f ." \
-                         "../build/examples/trixi_controller_data_c" \
-                         "../build/examples/trixi_controller_data_c ." \
-                         "../build/examples/trixi_controller_data_f" \
+                         "../build/examples/trixi_controller_data_c"     \
+                         "../build/examples/trixi_controller_data_c ."   \
+                         "../build/examples/trixi_controller_data_f"     \
                          "../build/examples/trixi_controller_data_f ."
             do
               $command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,6 @@ jobs:
           #   shell: bash
           #   test_type: valgrind
           #   julia_version: 1.9
-          # macOS
-          # - os: macos-latest
-          #   arch: x64
-          #   shell: bash
-          #   test_type: regular
-          #   julia_version: 1.9
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,25 +43,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Enable Julia cache
         uses: julia-actions/cache@v1
+
       - name: Enable t8code cache
         id: cache-t8code
         uses: actions/cache@v3
         with:
           path: ./t8code-local
           key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.T8CODE_RELEASE }}
+
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia_version }}
           arch: ${{ matrix.arch }}
+
       - name: Show Julia version information
         run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
+
       - name: Install dependencies available as Ubuntu packages
         # MPI, HDF5, Google Test
         run: |
           sudo apt-get install -y openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libgtest-dev
+
       - name: Install t8code
         if: steps.cache-t8code.outputs.cache-hit != 'true'
         run: |
@@ -76,12 +82,14 @@ jobs:
               --prefix=$PWD/../prefix --enable-mpi
           make -j 2
           make install
+
       - name: Configure (test_type == 'regular')
         if: ${{ matrix.test_type == 'regular' }}
         run: |
           mkdir build
           cd build
           cmake .. -DCMAKE_INSTALL_PREFIX=../install
+
       - name: Configure (test_type == 'coverage')
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
@@ -94,19 +102,23 @@ jobs:
                    -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
                    -DCMAKE_SHARED_LINKER_FLAGS="--coverage" \
                    -DENABLE_TESTING=ON -DJULIA_PROJECT_PATH=../libtrixi-julia
+
       - name: Build
         run: |
           cd build
           make -j 2
+
       - name: Install
         run: |
           cd build
           make install
+
       - name: Test building with an external Makefile
         if: ${{ matrix.test_type == 'regular' }}
         run: |
           cd examples
           make -f MakefileExternal LIBTRIXI_PREFIX=$PWD/../install
+
       - name: Initialize project directory
         # Note that we set the Julia depot to `~/.julia` *ONLY* to make use of the
         # julia-actions/cache above (which unfortunately hardcoded the `~/.julia`
@@ -124,12 +136,14 @@ jobs:
               --force
           cp ../install/share/libtrixi/LibTrixi.jl/examples/libelixir_tree1d_dgsem_advection_basic.jl .
           cp ../install/share/libtrixi/LibTrixi.jl/examples/libelixir_p4est2d_dgsem_euler_sedov.jl .
+
       - name: Prepare coverage reporting (test_type == 'coverage')
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
           sudo apt-get install -y lcov
           cd libtrixi-julia
           lcov --directory ../build --zerocounters
+
       - name: Run examples
         run: |
           cd libtrixi-julia
@@ -147,6 +161,7 @@ jobs:
               ../build/examples/trixi_controller_data_f . libelixir_p4est2d_dgsem_euler_sedov.jl
         env:
           LIBTRIXI_DEBUG: all
+
       - name: Run Julia tests
         uses: julia-actions/julia-runtest@v1
         with:
@@ -155,6 +170,7 @@ jobs:
         env:
           JULIA_DEPOT_PATH: ~/.julia
           LIBTRIXI_DEBUG: all
+
       - name: Check error handling of examples
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
@@ -178,6 +194,7 @@ jobs:
         env:
           LIBTRIXI_DEBUG: all
           JULIA_DEPOT_PATH: ~/.julia
+
       - name: Run CTest/gtest tests
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
@@ -186,16 +203,19 @@ jobs:
         env:
           LIBTRIXI_DEBUG: all
           JULIA_DEPOT_PATH: ~/.julia
+
       - name: Process C/Fortran coverage data
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
           cd libtrixi-julia
           lcov --directory ../build  --capture --output-file lcov.info
+
       - name: Process Julia coverage data
         if: ${{ matrix.test_type == 'coverage' }}
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: LibTrixi.jl/src
+
       - name: Upload coverage data (Codecov)
         uses: codecov/codecov-action@v3
         if: ${{ matrix.test_type == 'coverage' }}
@@ -203,12 +223,14 @@ jobs:
           files: ./libtrixi-julia/lcov.info,./lcov.info
           flags: unittests
           name: codecov-umbrella
+
       - name: Upload coverage data (Coveralls)
         if: ${{ matrix.test_type == 'coverage' }}
         uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           files: ./libtrixi-julia/lcov.info ./lcov.info
+
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session for debugging
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled && always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     env:
       # Necessary for HDF5 to play nice with Julia
       LD_PRELOAD: /lib/x86_64-linux-gnu/libcurl.so.4
+      # Necessary such that libtrixi will not use its own default for the depot path
+      JULIA_DEPOT_PATH: ~/.julia
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: "false"
 
+env:
+  # Modify this variable to change the t8code release version - do NOT hardcode the version
+  # anywhere else!
+  T8CODE_RELEASE: 1.4.1
+
 jobs:
   test:
     if: !contains(github.event.head_commit.message, 'skip ci')
@@ -53,6 +58,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Enable Julia cache
+        uses: julia-actions/cache@v1
+      - name: Enable t8code cache
+        id: cache-t8code
+        uses: actions/cache@v3
+        with:
+          path: ./t8code-local
+          key: ${{ matrix.os }}-${{ matrix.arch }}-${{ env.T8CODE_RELEASE }}
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
@@ -60,20 +73,13 @@ jobs:
           arch: ${{ matrix.arch }}
       - name: Show Julia version information
         run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
-      - name: Use Julia cache
-        uses: julia-actions/cache@v1
-      - name: Install MPI
+      - name: Install dependencies available as Ubuntu packages
+        # MPI, HDF5, Google Test
         run: |
-          sudo apt-get install -y openmpi-bin libopenmpi-dev
-      - name: Install HDF5
-        run: |
-          sudo apt-get install -y libhdf5-openmpi-dev
-      - name: Install gtest
-        run: |
-          sudo apt-get install -y libgtest-dev
+          sudo apt-get install -y openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libgtest-dev
       - name: Install t8code
+        if: steps.cache-t8code.outputs.cache-hit != 'true'
         run: |
-          T8CODE_RELEASE=1.4.1
           mkdir t8code-local
           cd t8code-local
           wget https://github.com/DLR-AMR/t8code/releases/download/v${T8CODE_RELEASE}/t8-${T8CODE_RELEASE}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,6 @@ jobs:
           #   shell: bash
           #   test_type: regular
           #   julia_version: 1.9
-          # Windows
-          # - os: windows-latest
-          #   arch: x64
-          #   shell: 'msys2 {0}'
-          #   test_type: regular
-          #   julia_version: 1.9
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:
@@ -65,11 +59,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: msys2/setup-msys2@v2
-        if: ${{ matrix.os == 'windows-latest' }}
-        with:
-          update: true
-          install: git base-devel mingw-w64-x86_64-toolchain
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=../install
+          cmake .. -DCMAKE_INSTALL_PREFIX=../install \
+                   -DCMAKE_BUILD_TYPE=Release \
+                   -DENABLE_TESTING=ON -DJULIA_PROJECT_PATH=../libtrixi-julia
 
       - name: Configure (test_type == 'coverage')
         if: ${{ matrix.test_type == 'coverage' }}
@@ -195,8 +197,7 @@ jobs:
           JULIA_DEPOT_PATH: ~/.julia
           LIBTRIXI_DEBUG: all
 
-      - name: Run CTest/gtest tests
-        if: ${{ matrix.test_type == 'coverage' }}
+      - name: Run C/Fortran tests
         run: |
           cd build/test
           ctest -V

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,12 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x64
-            shell: bash
             test_type: regular
             julia_version: 1.9
           - os: ubuntu-latest
             arch: x64
-            shell: bash
             test_type: coverage
             julia_version: 1.9
-    # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
     env:
       # Necessary for HDF5 to play nice with Julia
       LD_PRELOAD: /lib/x86_64-linux-gnu/libcurl.so.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux
           - os: ubuntu-latest
             arch: x64
             shell: bash
@@ -90,13 +89,13 @@ jobs:
               --prefix=$PWD/../prefix --enable-mpi
           make -j 2
           make install
-      - name: Configure (regular)
+      - name: Configure (test_type == 'regular')
         if: ${{ matrix.test_type == 'regular' }}
         run: |
           mkdir build
           cd build
           cmake .. -DCMAKE_INSTALL_PREFIX=../install
-      - name: Configure (coverage)
+      - name: Configure (test_type == 'coverage')
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
           mkdir build
@@ -138,14 +137,13 @@ jobs:
               --force
           cp ../install/share/libtrixi/LibTrixi.jl/examples/libelixir_tree1d_dgsem_advection_basic.jl .
           cp ../install/share/libtrixi/LibTrixi.jl/examples/libelixir_p4est2d_dgsem_euler_sedov.jl .
-      - name: Prepare coverage reporting
+      - name: Prepare coverage reporting (test_type == 'coverage')
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
           sudo apt-get install -y lcov
           cd libtrixi-julia
           lcov --directory ../build --zerocounters
-      - name: Run regular function tests
-        if: ${{ matrix.test_type == 'regular' }} || ${{ matrix.test_type == 'coverage' }}
+      - name: Run examples
         run: |
           cd libtrixi-julia
           JULIA_DEPOT_PATH=~/.julia \
@@ -218,7 +216,7 @@ jobs:
               ../build/examples/trixi_controller_data_c . libelixir_p4est2d_dgsem_euler_sedov.jl
           JULIA_DEPOT_PATH=~/.julia \
               ../build/examples/trixi_controller_data_f . libelixir_p4est2d_dgsem_euler_sedov.jl
-      - name: Process C coverage data
+      - name: Process C/Fortran coverage data
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
           cd libtrixi-julia
@@ -228,13 +226,14 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: LibTrixi.jl/src
-      - uses: codecov/codecov-action@v3
+      - name: Upload coverage data (Codecov)
+        uses: codecov/codecov-action@v3
         if: ${{ matrix.test_type == 'coverage' }}
         with:
           files: ./libtrixi-julia/lcov.info,./lcov.info
           flags: unittests
           name: codecov-umbrella
-      - name: Coveralls
+      - name: Upload coverage data (Coveralls)
         if: ${{ matrix.test_type == 'coverage' }}
         uses: coverallsapp/github-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    if: !contains(github.event.head_commit.message, 'skip ci')
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: ${{ matrix.os }} - ${{ matrix.test_type }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,6 @@ jobs:
             shell: bash
             test_type: coverage
             julia_version: 1.9
-          # - os: ubuntu-latest
-          #   arch: x64
-          #   shell: bash
-          #   test_type: valgrind
-          #   julia_version: 1.9
     # Set default shell as suggested here: https://github.community/t/setting-default-shell-or-other-step-metadata-conditionally-in-workflows/154055
     defaults:
       run:
@@ -199,23 +194,6 @@ jobs:
         env:
           LIBTRIXI_DEBUG: all
           JULIA_DEPOT_PATH: ~/.julia
-      - name: Run memory checks with Valgrind
-        if: ${{ matrix.test_type == 'valgrind' }}
-        run: |
-          sudo apt-get install -y valgrind
-          cd libtrixi-julia
-          JULIA_DEPOT_PATH=~/.julia valgrind --error-exitcode=1 -s \
-              ../build/examples/simple_trixi_controller_c . libelixir_tree1d_dgsem_advection_basic.jl
-          JULIA_DEPOT_PATH=~/.julia valgrind --error-exitcode=1 -s \
-              ../build/examples/simple_trixi_controller_f . libelixir_tree1d_dgsem_advection_basic.jl
-          JULIA_DEPOT_PATH=~/.julia valgrind --error-exitcode=1 -s \
-              ../build/examples/simple_trixi_controller_c . libelixir_p4est2d_dgsem_euler_sedov.jl
-          JULIA_DEPOT_PATH=~/.julia valgrind --error-exitcode=1 -s \
-              ../build/examples/simple_trixi_controller_f . libelixir_p4est2d_dgsem_euler_sedov.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/trixi_controller_data_c . libelixir_p4est2d_dgsem_euler_sedov.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/trixi_controller_data_f . libelixir_p4est2d_dgsem_euler_sedov.jl
       - name: Process C/Fortran coverage data
         if: ${{ matrix.test_type == 'coverage' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,18 +154,12 @@ jobs:
       - name: Run examples
         run: |
           cd libtrixi-julia
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/simple_trixi_controller_c . libelixir_tree1d_dgsem_advection_basic.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/simple_trixi_controller_f . libelixir_tree1d_dgsem_advection_basic.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/simple_trixi_controller_c . libelixir_p4est2d_dgsem_euler_sedov.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/simple_trixi_controller_f . libelixir_p4est2d_dgsem_euler_sedov.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/trixi_controller_data_c . libelixir_p4est2d_dgsem_euler_sedov.jl
-          JULIA_DEPOT_PATH=~/.julia \
-              ../build/examples/trixi_controller_data_f . libelixir_p4est2d_dgsem_euler_sedov.jl
+          ../build/examples/simple_trixi_controller_c . libelixir_tree1d_dgsem_advection_basic.jl
+          ../build/examples/simple_trixi_controller_f . libelixir_tree1d_dgsem_advection_basic.jl
+          ../build/examples/simple_trixi_controller_c . libelixir_p4est2d_dgsem_euler_sedov.jl
+          ../build/examples/simple_trixi_controller_f . libelixir_p4est2d_dgsem_euler_sedov.jl
+          ../build/examples/trixi_controller_data_c . libelixir_p4est2d_dgsem_euler_sedov.jl
+          ../build/examples/trixi_controller_data_f . libelixir_p4est2d_dgsem_euler_sedov.jl
         env:
           LIBTRIXI_DEBUG: all
 
@@ -191,7 +185,6 @@ jobs:
             done
         env:
           LIBTRIXI_DEBUG: all
-          JULIA_DEPOT_PATH: ~/.julia
 
       - name: Run Julia tests
         uses: julia-actions/julia-runtest@v1
@@ -199,7 +192,6 @@ jobs:
           coverage: ${{ matrix.test_type == 'coverage' }}
           project: ./LibTrixi.jl
         env:
-          JULIA_DEPOT_PATH: ~/.julia
           LIBTRIXI_DEBUG: all
 
       - name: Run C/Fortran tests
@@ -208,7 +200,6 @@ jobs:
           ctest -V
         env:
           LIBTRIXI_DEBUG: all
-          JULIA_DEPOT_PATH: ~/.julia
 
       - name: Process Julia coverage data
         if: ${{ matrix.test_type == 'coverage' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           cp ../install/share/libtrixi/LibTrixi.jl/examples/libelixir_tree1d_dgsem_advection_basic.jl .
           cp ../install/share/libtrixi/LibTrixi.jl/examples/libelixir_p4est2d_dgsem_euler_sedov.jl .
 
-      - name: Prepare coverage reporting (test_type == 'coverage')
+      - name: Prepare coverage reporting
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
           sudo apt-get install -y lcov
@@ -160,15 +160,6 @@ jobs:
           JULIA_DEPOT_PATH=~/.julia \
               ../build/examples/trixi_controller_data_f . libelixir_p4est2d_dgsem_euler_sedov.jl
         env:
-          LIBTRIXI_DEBUG: all
-
-      - name: Run Julia tests
-        uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: ${{ matrix.test_type == 'coverage' }}
-          project: ./LibTrixi.jl
-        env:
-          JULIA_DEPOT_PATH: ~/.julia
           LIBTRIXI_DEBUG: all
 
       - name: Check error handling of examples
@@ -195,6 +186,15 @@ jobs:
           LIBTRIXI_DEBUG: all
           JULIA_DEPOT_PATH: ~/.julia
 
+      - name: Run Julia tests
+        uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.test_type == 'coverage' }}
+          project: ./LibTrixi.jl
+        env:
+          JULIA_DEPOT_PATH: ~/.julia
+          LIBTRIXI_DEBUG: all
+
       - name: Run CTest/gtest tests
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
@@ -204,17 +204,17 @@ jobs:
           LIBTRIXI_DEBUG: all
           JULIA_DEPOT_PATH: ~/.julia
 
-      - name: Process C/Fortran coverage data
-        if: ${{ matrix.test_type == 'coverage' }}
-        run: |
-          cd libtrixi-julia
-          lcov --directory ../build  --capture --output-file lcov.info
-
       - name: Process Julia coverage data
         if: ${{ matrix.test_type == 'coverage' }}
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: LibTrixi.jl/src
+
+      - name: Process C/Fortran coverage data
+        if: ${{ matrix.test_type == 'coverage' }}
+        run: |
+          cd libtrixi-julia
+          lcov --directory ../build  --capture --output-file lcov.info
 
       - name: Upload coverage data (Codecov)
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ on:
         required: false
         default: "false"
 
-env:
-  # Modify this variable to change the t8code release version - do NOT hardcode the version
-  # anywhere else!
-  T8CODE_RELEASE: 1.4.1
-
 jobs:
   test:
     if: !contains(github.event.head_commit.message, 'skip ci')
@@ -31,15 +26,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            arch: x64
-            test_type: regular
-            julia_version: 1.9
-          - os: ubuntu-latest
-            arch: x64
-            test_type: coverage
-            julia_version: 1.9
+        os:
+          - ubuntu-latest
+        test_type:
+          - regular
+          - coverage
+        arch:
+          - x64
+        julia_version:
+          - '1.9'
+        t8code_version:
+          - '1.4.1'
     env:
       # Necessary for HDF5 to play nice with Julia
       LD_PRELOAD: /lib/x86_64-linux-gnu/libcurl.so.4
@@ -68,6 +65,7 @@ jobs:
       - name: Install t8code
         if: steps.cache-t8code.outputs.cache-hit != 'true'
         run: |
+          T8CODE_RELEASE=${{ matrix.t8code_version }}
           mkdir t8code-local
           cd t8code-local
           wget https://github.com/DLR-AMR/t8code/releases/download/v${T8CODE_RELEASE}/t8-${T8CODE_RELEASE}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: !contains(github.event.head_commit.message, 'skip ci')
     name: ${{ matrix.os }} - ${{ matrix.test_type }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,15 @@ jobs:
         run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
 
       - name: Install dependencies available as Ubuntu packages
-        # MPI, HDF5, Google Test
+        # - MPI
+        # - HDF5
+        # - Google Test
+        # - Coverage (lcov)
         run: |
-          sudo apt-get install -y openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libgtest-dev
+          sudo apt-get install -y openmpi-bin libopenmpi-dev \
+                                  libhdf5-openmpi-dev \
+                                  libgtest-dev \
+                                  lcov
 
       - name: Install t8code
         if: steps.cache-t8code.outputs.cache-hit != 'true'
@@ -142,7 +148,6 @@ jobs:
       - name: Prepare coverage reporting
         if: ${{ matrix.test_type == 'coverage' }}
         run: |
-          sudo apt-get install -y lcov
           cd libtrixi-julia
           lcov --directory ../build --zerocounters
 


### PR DESCRIPTION
This PR combines various small CI improvements that hopefully make it easier to understand or adapt the main CI testing config file. Since a lot in the file has changed, I recommend for a review to either directly read the entire new file and not look at the diff, or to just step through all commit diffs manually to understand the changes that have been performed.

Here's a summary of the main modifications:
* Throw out unused configurations (Windows, macOS, Valgrind)
* Enable caching of t8code installation (to save ~3 minutes)
* Simplify the job configuration by using a simpler matrix
* Execute Google Tests also in 'regular' runs

Some of the changes might be too far reaching, so feel free to comment/question these choices.