### PR TITLE
Make TagBot work again (at all)

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -30,3 +30,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          subdir: LibTrixi.jl
+          tag_prefix: NO_PREFIX

--- a/Project.toml
+++ b/Project.toml
@@ -1,1 +1,0 @@
-LibTrixi.jl/Project.toml

--- a/docs/src/developers.md
+++ b/docs/src/developers.md
@@ -11,10 +11,6 @@ publishing new Julia package releases.  Specifically, that means
 * we rely on the Julia [TagBot](https://github.com/JuliaRegistries/TagBot)
   to create associacted tags and GitHub releases once the Julia package is registered.
 
-To support the ability to have TagBot create top-level releases even though the Julia
-package LibTrixi.jl lives in a subdirectory, we have symlinked `LibTrixi.jl/Project.toml` to
-the repository root.
-
 ### Creating a new release
 To create a new libtrixi release, follow these steps:
 1. Ensure that all tests have passed for the current commit in `main` and that coverage is
@@ -36,8 +32,8 @@ To create a new libtrixi release, follow these steps:
    (e.g., if you did not skip a version number), the new version will become active after
    about 15 minutes. See the full set of rules
    [here](https://github.com/JuliaRegistries/Registrator.jl/).
-4. The Julia Registrator app is chatty and will let you know if your registration request
-   meets all criteria for an auto-merge. Once this is the case, bump the version in
+4. The Julia Registrator app is chatty and will let you know in the PR if your registration
+   request meets all criteria for an auto-merge. Once this is the case, bump the version in
    [`LibTrixi.jl/Project.toml`](https://github.com/trixi-framework/libtrixi/blob/main/LibTrixi.jl/Project.toml)
    again and set it to the next development version. We do this to prevent confusion about
    whether the current state of the repository is identical to the latest release or not.  


### PR DESCRIPTION
With https://github.com/JuliaRegistries/TagBot/pull/279 merged, we need to wait for a new version of the TagBot action to be tagged (no pun intended). Once this has happened, we should be able to use TagBot for automatic new release creation.