### PR TITLE
Remove `LD_PRELOAD` for libcurl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
         t8code_version:
           - '1.4.1'
     env:
-      # Necessary for HDF5 to play nice with Julia
-      LD_PRELOAD: /lib/x86_64-linux-gnu/libcurl.so.4
       # Necessary such that libtrixi will not use its own default for the depot path
       JULIA_DEPOT_PATH: ~/.julia
     steps:


### PR DESCRIPTION
Hopefully this fixes errors such as this one:
https://github.com/trixi-framework/libtrixi/actions/runs/6156341659/job/16705469730#step:14:519
