### PR TITLE
Store version info at compile time

### DIFF
--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -63,25 +63,52 @@ export SimulationState, store_simstate, load_simstate, delete_simstate!
 
 
 # global storage of name and version information of loaded packages
-function assemble_version_info(; filter_expr = identity)
+function assemble_version_info(; filter_expr = identity, include_julia = true)
     packages = Pkg.dependencies() |> values |> collect |> filter_expr
     versions = String[]
-    for p in sort(packages, by=x->x.name)
+    found_libtrixi = false
+    for p in packages
         if isnothing(p.version)
             push!(versions, p.name * " n/a")
         else
             push!(versions, p.name * " " * string(p.version))
         end
+        if p.name == "LibTrixi"
+            found_libtrixi = true
+        end
     end
-    push!(versions, "julia " * string(VERSION))
-    join(versions, "\n")
+
+    # When running Julia with the LibTrixi package dir as the active project,
+    # Pkg.dependencies() will not return LibTrixi itself, which is remedied here
+    if !found_libtrixi && Pkg.project().name == "LibTrixi"
+        push!(versions, "LibTrixi " * string(Pkg.project().version))
+    end
+
+    sort!(versions)
+
+    # Add Julia version
+    if include_julia
+        push!(versions, "julia " * string(VERSION))
+    end
+
+    return join(versions, "\n")
 end
 
 const _version_info = assemble_version_info(filter_expr = filter(p -> p.is_direct_dep))
 const _version_info_extended = assemble_version_info()
 const _version_libtrixi = begin
-    libtrixi_string = assemble_version_info(filter_expr = filter(p -> p.name == "LibTrixi"))
-    split(split(libtrixi_string, "\n")[1], " ")[2]
+    libtrixi_string = assemble_version_info(filter_expr = filter(p -> p.name == "LibTrixi"),
+                                            include_julia = false)
+
+    # When running Julia with the LibTrixi package dir as the active project,
+    # Pkg.dependencies() will not return LibTrixi itself, which is remedied here
+    if isempty(libtrixi_string)
+        version_string = string(Pkg.project().version)
+    else
+        version_string = split(libtrixi_string, " ")[2]
+    end
+
+    version_string
 end
 
 

--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -63,9 +63,12 @@ export SimulationState, store_simstate, load_simstate, delete_simstate!
 
 
 # global storage of name and version information of loaded packages
-const _version_info = Ref("")
-const _version_info_extended = Ref("")
-const _version_libtrixi = Ref("")
+const _version_info = assemble_version_info(filter_expr = filter(p -> p.is_direct_dep))
+const _version_info_extended = assemble_version_info()
+const _version_libtrixi = begin
+    libtrixi_string = assemble_version_info(filter_expr = filter(p -> p.name == "LibTrixi"))
+    split(split(libtrixi_string, "\n")[1], " ")[2]
+end
 
 
 include("simulationstate.jl")
@@ -111,12 +114,6 @@ function __init__()
     if show_debug_output()
         MPI.set_default_error_handler_return()
     end
-
-    # assemble packages information
-    _version_info[] = assemble_version_info(filter_expr = filter(p -> p.is_direct_dep))
-    _version_info_extended[] = assemble_version_info()
-    libtrixi_string = assemble_version_info(filter_expr = filter(p -> p.name == "LibTrixi"))
-    _version_libtrixi[] = split(split(libtrixi_string, "\n")[1], " ")[2]
 end
 
 end # module LibTrixi

--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -63,6 +63,20 @@ export SimulationState, store_simstate, load_simstate, delete_simstate!
 
 
 # global storage of name and version information of loaded packages
+function assemble_version_info(; filter_expr = identity)
+    packages = Pkg.dependencies() |> values |> collect |> filter_expr
+    versions = String[]
+    for p in sort(packages, by=x->x.name)
+        if isnothing(p.version)
+            push!(versions, p.name * " n/a")
+        else
+            push!(versions, p.name * " " * string(p.version))
+        end
+    end
+    push!(versions, "julia " * string(VERSION))
+    join(versions, "\n")
+end
+
 const _version_info = assemble_version_info(filter_expr = filter(p -> p.is_direct_dep))
 const _version_info_extended = assemble_version_info()
 const _version_libtrixi = begin
@@ -87,21 +101,6 @@ function show_debug_output()
     else
         return false
     end
-end
-
-
-function assemble_version_info(; filter_expr = identity)
-    packages = Pkg.dependencies() |> values |> collect |> filter_expr
-    versions = String[]
-    for p in sort(packages, by=x->x.name)
-        if isnothing(p.version)
-            push!(versions, p.name * " n/a")
-        else
-            push!(versions, p.name * " " * string(p.version))
-        end
-    end
-    push!(versions, "julia " * string(VERSION))
-    join(versions, "\n")
 end
 
 

--- a/LibTrixi.jl/src/api_c.jl
+++ b/LibTrixi.jl/src/api_c.jl
@@ -12,7 +12,7 @@ This function is thread-safe. It must be run after `trixi_initialize` has been c
 function trixi_version_library_major end
 
 Base.@ccallable function trixi_version_library_major()::Cint
-    return VersionNumber(_version_libtrixi[]).major
+    return VersionNumber(_version_libtrixi).major
 end
 
 trixi_version_library_major_cfptr() = @cfunction(trixi_version_library_major, Cint, ())
@@ -28,7 +28,7 @@ This function is thread-safe. It must be run after `trixi_initialize` has been c
 function trixi_version_library_minor end
 
 Base.@ccallable function trixi_version_library_minor()::Cint
-    return VersionNumber(_version_libtrixi[]).minor
+    return VersionNumber(_version_libtrixi).minor
 end
 
 trixi_version_library_minor_cfptr() = @cfunction(trixi_version_library_minor, Cint, ())
@@ -44,7 +44,7 @@ This function is thread-safe. It must be run after `trixi_initialize` has been c
 function trixi_version_library_patch end
 
 Base.@ccallable function trixi_version_library_patch()::Cint
-    return VersionNumber(_version_libtrixi[]).patch
+    return VersionNumber(_version_libtrixi).patch
 end
 
 trixi_version_library_patch_cfptr() = @cfunction(trixi_version_library_patch, Cint, ())
@@ -67,7 +67,7 @@ This function is thread-safe. It must be run after `trixi_initialize` has been c
 function trixi_version_library end
 
 Base.@ccallable function trixi_version_library()::Cstring
-    return pointer(_version_libtrixi[])
+    return pointer(_version_libtrixi)
 end
 
 trixi_version_library_cfptr() = @cfunction(trixi_version_library, Cstring, ())
@@ -89,7 +89,7 @@ This function is thread-safe. It must be run after `trixi_initialize` has been c
 function trixi_version_julia end
 
 Base.@ccallable function trixi_version_julia()::Cstring
-    return pointer(_version_info[])
+    return pointer(_version_info)
 end
 
 trixi_version_julia_cfptr() = @cfunction(trixi_version_julia, Cstring, ())
@@ -112,7 +112,7 @@ This function is thread-safe. It must be run after `trixi_initialize` has been c
 function trixi_version_julia_extended end
 
 Base.@ccallable function trixi_version_julia_extended()::Cstring
-    return pointer(_version_info_extended[])
+    return pointer(_version_info_extended)
 end
 
 trixi_version_julia_extended_cfptr() = @cfunction(trixi_version_julia_extended, Cstring, ())


### PR DESCRIPTION
It was an oversight of myself to fill the version info arrays at *runtime* instead of *compile time*. Since the module gets recompiled whenever one of its (transitive) dependencies changes, this should always be up-to-date anyways.

This change hopefully fixes some issues encountered when trying to build libtrixi with PackageCompiler.jl.