### PR TITLE
Update codecov to v4 and add token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,12 +305,13 @@ jobs:
                --output-file lcov.info
 
       - name: Upload coverage data (Codecov)
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: ${{ matrix.test_type == 'coverage' }}
         with:
           files: ./libtrixi-julia/lcov.info,./lcov.info
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage data (Coveralls)
         if: ${{ matrix.test_type == 'coverage' }}


### PR DESCRIPTION
Got the token from https://app.codecov.io/gh/trixi-framework/libtrixi/settings
and followed https://github.com/codecov/codecov-action?tab=readme-ov-file#usage