### PR TITLE
RFC: Source terms via callback

### DIFF
--- a/LibTrixi.jl/examples/libelixir_structured2d_source_terms_callback.jl
+++ b/LibTrixi.jl/examples/libelixir_structured2d_source_terms_callback.jl
@@ -4,9 +4,7 @@ using OrdinaryDiffEq
 using Libdl
 
 # TODO: hard-coded path for SO
-so_handle = dlopen("/home/bene/trixi/libtrixi/build/examples/libsource_terms.so")
-println("")
-println(pwd())
+so_handle = dlopen("./lib/libsource_terms.so")
 println("Opened library ", dlpath(so_handle))
 source_term_fptr = dlsym(so_handle, "source_term_wave")
 println("Obtained function pointer ", source_term_fptr)

--- a/LibTrixi.jl/examples/libelixir_structured2d_source_terms_callback.jl
+++ b/LibTrixi.jl/examples/libelixir_structured2d_source_terms_callback.jl
@@ -1,0 +1,86 @@
+using LibTrixi
+using Trixi
+using OrdinaryDiffEq
+using Libdl
+
+# TODO: hard-coded path for SO
+so_handle = dlopen("/home/bene/trixi/libtrixi/build/examples/libsource_terms.so")
+println("")
+println(pwd())
+println("Opened library ", dlpath(so_handle))
+source_term_fptr = dlsym(so_handle, "source_term_wave")
+println("Obtained function pointer ", source_term_fptr)
+
+# TODO: global buffer to avoid allocation of temporary storage in source_term_callback
+sources_tmp::Vector{Cdouble} = Vector{Cdouble}(undef, 4)
+
+function source_term_callback(u, x, t, equations::CompressibleEulerEquations2D)
+    @ccall $source_term_fptr(u::Ptr{Cdouble}, x::Ptr{Cdouble}, t::Cdouble,
+                                      equations.gamma::Cdouble,
+                                      sources_tmp::Ptr{Cdouble})::Cvoid
+    return SVector(sources_tmp[1], sources_tmp[2], sources_tmp[3], sources_tmp[4])
+end
+
+# The function to create the simulation state needs to be named `init_simstate`
+function init_simstate()
+
+    ###############################################################################
+    # semidiscretization of the compressible Euler equations
+
+    equations = CompressibleEulerEquations2D(1.4)
+
+    initial_condition = initial_condition_convergence_test
+
+    solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)
+
+    coordinates_min = (0.0, 0.0)
+    coordinates_max = (2.0, 2.0)
+
+    cells_per_dimension = (16, 16)
+
+    mesh = StructuredMesh(cells_per_dimension, coordinates_min, coordinates_max)
+
+    semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                        source_terms = source_term_callback)
+
+    ###############################################################################
+    # ODE solvers, callbacks etc.
+
+    tspan = (0.0, 2.0)
+    ode = semidiscretize(semi, tspan)
+
+    summary_callback = SummaryCallback()
+
+    analysis_interval = 100
+    analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
+
+    alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+    save_solution = SaveSolutionCallback(interval = 100,
+                                        save_initial_solution = true,
+                                        save_final_solution = true,
+                                        solution_variables = cons2prim)
+
+    stepsize_callback = StepsizeCallback(cfl = 1.0)
+
+    callbacks = CallbackSet(summary_callback,
+                            analysis_callback, alive_callback,
+                            save_solution,
+                            stepsize_callback)
+
+    ###############################################################################
+    # create OrdinaryDiffEq's `integrator`
+
+    integrator = init(ode,
+                      CarpenterKennedy2N54(williamson_condition=false),
+                      dt=1.0, # will be overwritten by the stepsize_callback
+                      save_everystep=false,
+                      callback=callbacks);
+
+    ###############################################################################
+    # Create simulation state
+
+    simstate = SimulationState(semi, integrator)
+
+    return simstate
+end

--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -43,6 +43,9 @@ export trixi_nvariables,
 export trixi_load_cell_averages,
        trixi_load_cell_averages_cfptr,
        trixi_load_cell_averages_jl
+export trixi_load_prim,
+       trixi_load_prim_cfptr,
+       trixi_load_prim_jl
 export trixi_version_library,
        trixi_version_library_cfptr,
        trixi_version_library_jl

--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -1,7 +1,7 @@
 module LibTrixi
 
 using OrdinaryDiffEq: OrdinaryDiffEq, step!, check_error, DiscreteCallback
-using Trixi: Trixi, summary_callback, mesh_equations_solver_cache, nelements,
+using Trixi: Trixi, summary_callback, mesh_equations_solver_cache, ndims, nelements,
              nelementsglobal, ndofs, ndofsglobal, nvariables, nnodes, wrap_array,
              eachelement, cons2prim, get_node_vars, eachnode
 using MPI: MPI, run_init_hooks, set_default_error_handler_return
@@ -37,6 +37,9 @@ export trixi_ndofs,
 export trixi_ndofs_global,
        trixi_ndofs_global_cfptr,
        trixi_ndofs_global_jl
+export trixi_ndofs_element,
+       trixi_ndofs_element_cfptr,
+       trixi_ndofs_element_jl
 export trixi_nvariables,
        trixi_nvariables_cfptr,
        trixi_nvariables_jl

--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -2,8 +2,8 @@ module LibTrixi
 
 using OrdinaryDiffEq: OrdinaryDiffEq, step!, check_error, DiscreteCallback
 using Trixi: Trixi, summary_callback, mesh_equations_solver_cache, nelements,
-             nelementsglobal, nvariables, nnodes, wrap_array, eachelement, cons2prim,
-             get_node_vars, eachnode
+             nelementsglobal, ndofs, ndofsglobal, nvariables, nnodes, wrap_array,
+             eachelement, cons2prim, get_node_vars, eachnode
 using MPI: MPI, run_init_hooks, set_default_error_handler_return
 using Pkg
 
@@ -31,6 +31,12 @@ export trixi_nelements,
 export trixi_nelements_global,
        trixi_nelements_global_cfptr,
        trixi_nelements_global_jl
+export trixi_ndofs,
+       trixi_ndofs_cfptr,
+       trixi_ndofs_jl
+export trixi_ndofs_global,
+       trixi_ndofs_global_cfptr,
+       trixi_ndofs_global_jl
 export trixi_nvariables,
        trixi_nvariables_cfptr,
        trixi_nvariables_jl

--- a/LibTrixi.jl/src/api_c.jl
+++ b/LibTrixi.jl/src/api_c.jl
@@ -386,6 +386,35 @@ trixi_load_cell_averages_cfptr() =
 
 
 """
+    trixi_load_prim(data::Ptr{Cdouble}, index::Cint, simstate_handle::Cint)::Cvoid
+
+Return primitive variable.
+
+The values for the primitive variable at position `index` at every degree of freedom for
+the simulation given by `simstate_handle` is stored in the given array `data`.
+
+The given array has to be of correct size and memory has to be allocated beforehand.
+"""
+function trixi_load_prim end
+
+Base.@ccallable function trixi_load_prim(data::Ptr{Cdouble}, index::Cint,
+                                         simstate_handle::Cint)::Cvoid
+    simstate = load_simstate(simstate_handle)
+
+    # convert C to Julia array
+    size = trixi_ndofs_jl(simstate)
+    data_jl = unsafe_wrap(Array, data, size)
+
+    trixi_load_prim_jl(data_jl, index, simstate)
+    return nothing
+end
+
+trixi_load_prim_cfptr() =
+    @cfunction(trixi_load_prim, Cvoid, (Ptr{Cdouble}, Cint, Cint,))
+
+
+
+"""
     trixi_get_t8code_forest(simstate_handle::Cint)::::Ptr{Trixi.t8_forest}
 
 Return t8code forest of the current T8codeMesh.

--- a/LibTrixi.jl/src/api_c.jl
+++ b/LibTrixi.jl/src/api_c.jl
@@ -343,6 +343,21 @@ trixi_ndofs_global_cfptr() = @cfunction(trixi_ndofs_global, Cint, (Cint,))
 
 
 """
+    trixi_ndofs_element(simstate_handle::Cint)::Cint
+
+Return number of degrees of freedom per element (cell).
+"""
+function trixi_ndofs_element end
+
+Base.@ccallable function trixi_ndofs_element(simstate_handle::Cint)::Cint
+    simstate = load_simstate(simstate_handle)
+    return trixi_ndofs_element_jl(simstate)
+end
+
+trixi_ndofs_element_cfptr() = @cfunction(trixi_ndofs_element, Cint, (Cint,))
+
+
+"""
     trixi_nvariables(simstate_handle::Cint)::Cint
 
 Return number of variables.

--- a/LibTrixi.jl/src/api_c.jl
+++ b/LibTrixi.jl/src/api_c.jl
@@ -358,19 +358,18 @@ trixi_nvariables_cfptr() = @cfunction(trixi_nvariables, Cint, (Cint,))
 
 
 """
-    trixi_load_cell_averages(data::Ptr{Cdouble}, simstate_handle::Cint)::Cvoid
+    trixi_load_cell_averages(data::Ptr{Cdouble}, index::Cint, simstate_handle::Cint)::Cvoid
 
 Return cell averaged solution state.
 
-Cell averaged values for each cell and each primitive variable are stored in a contiguous
-array, where cell values for the first variable appear first and values for the other
-variables subsequently (structure-of-arrays layout).
+Cell averaged values for the primitive variable at position `index` for each cell are stored
+in the given array `data`.
 
 The given array has to be of correct size and memory has to be allocated beforehand.
 """
 function trixi_load_cell_averages end
 
-Base.@ccallable function trixi_load_cell_averages(data::Ptr{Cdouble},
+Base.@ccallable function trixi_load_cell_averages(data::Ptr{Cdouble}, index::Cint,
                                                   simstate_handle::Cint)::Cvoid
     simstate = load_simstate(simstate_handle)
 
@@ -378,12 +377,12 @@ Base.@ccallable function trixi_load_cell_averages(data::Ptr{Cdouble},
     size = trixi_nvariables_jl(simstate) * trixi_nelements_jl(simstate)
     data_jl = unsafe_wrap(Array, data, size)
 
-    trixi_load_cell_averages_jl(data_jl, simstate)
+    trixi_load_cell_averages_jl(data_jl, index, simstate)
     return nothing
 end
 
 trixi_load_cell_averages_cfptr() =
-    @cfunction(trixi_load_cell_averages, Cvoid, (Ptr{Cdouble}, Cint,))
+    @cfunction(trixi_load_cell_averages, Cvoid, (Ptr{Cdouble}, Cint, Cint,))
 
 
 """

--- a/LibTrixi.jl/src/api_c.jl
+++ b/LibTrixi.jl/src/api_c.jl
@@ -313,6 +313,36 @@ trixi_nelements_global_cfptr() = @cfunction(trixi_nelements_global, Cint, (Cint,
 
 
 """
+    trixi_ndofs(simstate_handle::Cint)::Cint
+
+Return number of degrees of freedom (all quadrature points on all cells of current rank).
+"""
+function trixi_ndofs end
+
+Base.@ccallable function trixi_ndofs(simstate_handle::Cint)::Cint
+    simstate = load_simstate(simstate_handle)
+    return trixi_ndofs_jl(simstate)
+end
+
+trixi_ndofs_cfptr() = @cfunction(trixi_ndofs, Cint, (Cint,))
+
+
+"""
+    trixi_ndofs_global(simstate_handle::Cint)::Cint
+
+Return number of global eldegrees of freedom (all quadrature points on all cells).
+"""
+function trixi_ndofs_global end
+
+Base.@ccallable function trixi_ndofs_global(simstate_handle::Cint)::Cint
+    simstate = load_simstate(simstate_handle)
+    return trixi_ndofs_global_jl(simstate)
+end
+
+trixi_ndofs_global_cfptr() = @cfunction(trixi_ndofs_global, Cint, (Cint,))
+
+
+"""
     trixi_nvariables(simstate_handle::Cint)::Cint
 
 Return number of variables.

--- a/LibTrixi.jl/src/api_jl.jl
+++ b/LibTrixi.jl/src/api_jl.jl
@@ -94,6 +94,12 @@ function trixi_ndofs_global_jl(simstate)
 end
 
 
+function trixi_ndofs_element_jl(simstate)
+    mesh, _, solver, _ = mesh_equations_solver_cache(simstate.semi)
+    return nnodes(solver)^ndims(mesh)
+end
+
+
 function trixi_nvariables_jl(simstate)
     _, equations, _, _ = mesh_equations_solver_cache(simstate.semi)
     return nvariables(equations)

--- a/LibTrixi.jl/src/api_jl.jl
+++ b/LibTrixi.jl/src/api_jl.jl
@@ -82,6 +82,18 @@ function trixi_nelements_global_jl(simstate)
 end
 
 
+function trixi_ndofs_jl(simstate)
+    mesh, _, solver, cache = mesh_equations_solver_cache(simstate.semi)
+    return ndofs(mesh, solver, cache)
+end
+
+
+function trixi_ndofs_global_jl(simstate)
+    mesh, _, solver, cache = mesh_equations_solver_cache(simstate.semi)
+    return ndofsglobal(mesh, solver, cache)
+end
+
+
 function trixi_nvariables_jl(simstate)
     _, equations, _, _ = mesh_equations_solver_cache(simstate.semi)
     return nvariables(equations)

--- a/LibTrixi.jl/src/api_jl.jl
+++ b/LibTrixi.jl/src/api_jl.jl
@@ -136,6 +136,31 @@ function trixi_load_cell_averages_jl(data, index, simstate)
 end
 
 
+function trixi_load_prim_jl(data, index, simstate)
+    mesh, equations, solver, cache = mesh_equations_solver_cache(simstate.semi)
+    n_nodes_per_dim = nnodes(solver)
+    n_dims = ndims(mesh)
+    n_nodes = n_nodes_per_dim^n_dims
+
+    u_ode = simstate.integrator.u
+    u = wrap_array(u_ode, mesh, equations, solver, cache)
+
+    # all permutations of nodes indices for arbitrary dimension
+    node_cis = CartesianIndices(ntuple(i -> n_nodes_per_dim, n_dims))
+    node_lis = LinearIndices(node_cis)
+
+    for element in eachelement(solver, cache)
+        for node_ci in node_cis
+            node_vars = get_node_vars(u, equations, solver, node_ci, element)
+            node_index = (element-1) * n_nodes + node_lis[node_ci]
+            data[node_index] = cons2prim(node_vars, equations)[index]
+        end
+    end
+
+    return nothing
+end
+
+
 function trixi_get_t8code_forest_jl(simstate)
     mesh, _, _, _ = Trixi.mesh_equations_solver_cache(simstate.semi)
     return mesh.forest

--- a/LibTrixi.jl/test/test_interface.jl
+++ b/LibTrixi.jl/test/test_interface.jl
@@ -81,6 +81,19 @@ end
     nelements_global_jl = trixi_nelements_global_jl(simstate_jl)
     @test nelements_global_c == nelements_global_jl
 
+    # compare number of dofs
+    ndofs_c = trixi_ndofs(handle)
+    ndofs_jl = trixi_ndofs_jl(simstate_jl)
+    @test ndofs_c == ndofs_jl
+
+    ndofs_global_c = trixi_ndofs_global(handle)
+    ndofs_global_jl = trixi_ndofs_global_jl(simstate_jl)
+    @test ndofs_global_c == ndofs_global_jl
+
+    ndofs_element_c = trixi_ndofs_element(handle)
+    ndofs_element_jl = trixi_ndofs_element_jl(simstate_jl)
+    @test ndofs_element_c == ndofs_element_jl
+
     # compare number of variables
     nvariables_c = trixi_nvariables(handle)
     nvariables_jl = trixi_nvariables_jl(simstate_jl)
@@ -91,6 +104,13 @@ end
     trixi_load_cell_averages(pointer(data_c), Int32(1), handle)
     data_jl = zeros(nelements_jl)
     trixi_load_cell_averages_jl(data_jl, 1, simstate_jl)
+    @test data_c == data_jl
+
+    # compare primitive variable values on all dofs
+    data_c = zeros(ndofs_c)
+    trixi_load_prim(pointer(data_c), Int32(1), handle)
+    data_jl = zeros(ndofs_jl)
+    trixi_load_prim_jl(data_jl, 1, simstate_jl)
     @test data_c == data_jl
 end
 

--- a/LibTrixi.jl/test/test_interface.jl
+++ b/LibTrixi.jl/test/test_interface.jl
@@ -87,10 +87,10 @@ end
     @test nvariables_c == nvariables_jl
 
     # compare cell averaged values
-    data_c = zeros(nvariables_c * nelements_c)
-    trixi_load_cell_averages(pointer(data_c), handle)
-    data_jl = zeros(nvariables_jl * nelements_jl)
-    trixi_load_cell_averages_jl(data_jl, simstate_jl)
+    data_c = zeros(nelements_c)
+    trixi_load_cell_averages(pointer(data_c), 1, handle)
+    data_jl = zeros(nelements_jl)
+    trixi_load_cell_averages_jl(data_jl, 1, simstate_jl)
     @test data_c == data_jl
 end
 

--- a/LibTrixi.jl/test/test_interface.jl
+++ b/LibTrixi.jl/test/test_interface.jl
@@ -88,7 +88,7 @@ end
 
     # compare cell averaged values
     data_c = zeros(nelements_c)
-    trixi_load_cell_averages(pointer(data_c), 1, handle)
+    trixi_load_cell_averages(pointer(data_c), Int32(1), handle)
     data_jl = zeros(nelements_jl)
     trixi_load_cell_averages_jl(data_jl, 1, simstate_jl)
     @test data_c == data_jl

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,14 @@ if ( NOT T8CODE_FOUND )
     list( FILTER EXAMPLES EXCLUDE REGEX ".*(t|T)8(c|C)(o|O)(d|D)(e|E).*" )
 endif()
 
+# example standalone library with callback
+add_library ( source_terms SHARED
+    source_terms.h
+    source_terms.c
+)
+install( TARGETS source_terms )
+
+
 foreach ( EXAMPLE ${EXAMPLES} )
 
     get_filename_component ( EXAMPLE_EXT ${EXAMPLE} EXT )

--- a/examples/source_terms.c
+++ b/examples/source_terms.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <math.h>
+
+/* 
+ * Example for an external source term evaluation
+ * Diagonally running wave, taken from Trixi.jl's source_terms_convergence_test
+ */
+void source_term_wave(const double * u, const double * x, const double t,
+                      const double gamma, double * sourceterm) {
+
+    const double c = 2.0;
+    const double A = 0.1;
+    const double L = 2.0;
+    const double f = 1.0 / L;
+    const double omega = 2 * M_PI * f;
+
+    const double si = sin(omega * (x[0] + x[1] - t));
+    const double co = cos(omega * (x[0] + x[1] - t));
+    const double rho = c + A * si;
+    const double rho_x = omega * A * co;
+    const double tmp = (2 * rho - 1) * (gamma - 1);
+
+    sourceterm[0] = rho_x;
+    sourceterm[1] = rho_x * (1 + tmp);
+    sourceterm[2] = sourceterm[1];
+    sourceterm[3] = 2 * rho_x * (rho + tmp);
+}

--- a/examples/source_terms.h
+++ b/examples/source_terms.h
@@ -1,0 +1,2 @@
+void source_term_wave(const double * u, const double * x, const double t,
+                      const double gamma, double * sourceterm);

--- a/examples/trixi_controller_data.c
+++ b/examples/trixi_controller_data.c
@@ -46,10 +46,10 @@ int main ( int argc, char *argv[] ) {
             printf("\n*** Trixi controller ***   nelements %d\n", nelements);
 
             // Allocate memory
-            data = realloc( data, sizeof(double) * nelements * nvariables );
+            data = realloc( data, sizeof(double) * nelements );
 
-            // Get averaged cell values for each variable
-            trixi_load_cell_averages(data, handle);
+            // Get averaged cell values for first variable
+            trixi_load_cell_averages(data, 1, handle);
         }
     }
 

--- a/examples/trixi_controller_data.f90
+++ b/examples/trixi_controller_data.f90
@@ -63,10 +63,10 @@ program trixi_controller_data_f
 
       ! allocate memory
       if ( associated(data) ) deallocate(data)
-      allocate( data(nelements*nvariables) )
+      allocate( data(nelements) )
 
-      ! get averaged cell values for each variable
-      call trixi_load_cell_averages(data, handle)
+      ! get averaged cell values for first variable
+      call trixi_load_cell_averages(data, 1, handle)
     end if
   end do
 

--- a/src/api.c
+++ b/src/api.c
@@ -19,6 +19,7 @@ enum {
     TRIXI_FPTR_NDOFS_GLOBAL,
     TRIXI_FTPR_NVARIABLES,
     TRIXI_FTPR_LOAD_CELL_AVERAGES,
+    TRIXI_FTPR_LOAD_PRIM,
     TRIXI_FTPR_VERSION_LIBRARY,
     TRIXI_FTPR_VERSION_LIBRARY_MAJOR,
     TRIXI_FTPR_VERSION_LIBRARY_MINOR,
@@ -50,6 +51,7 @@ static const char* trixi_function_pointer_names[] = {
     [TRIXI_FPTR_NDOFS_GLOBAL]           = "trixi_ndofs_global_cfptr",
     [TRIXI_FTPR_NVARIABLES]             = "trixi_nvariables_cfptr",
     [TRIXI_FTPR_LOAD_CELL_AVERAGES]     = "trixi_load_cell_averages_cfptr",
+    [TRIXI_FTPR_LOAD_PRIM]              = "trixi_load_prim_cfptr",
     [TRIXI_FTPR_VERSION_LIBRARY]        = "trixi_version_library_cfptr",
     [TRIXI_FTPR_VERSION_LIBRARY_MAJOR]  = "trixi_version_library_major_cfptr",
     [TRIXI_FTPR_VERSION_LIBRARY_MINOR]  = "trixi_version_library_minor_cfptr",
@@ -576,6 +578,29 @@ void trixi_load_cell_averages(double * data, int index, int handle) {
 }
 
 
+/**
+ * @anchor trixi_load_prim_api_c
+ *
+ * @brief Return primitive variable
+ *
+ * The values for the primitive variable at position index at every degree of freedom for
+ * the simulation given by simstate_handle is stored in the given array data.
+ *
+ * The given array has to be of correct size and memory has to be allocated beforehand.
+ *
+ * @param[in]  handle  simulation handle
+ * @param[in]  index   index of variable
+ * @param[out] data    cell averaged values for all cells and all primitive variables
+ */
+void trixi_load_prim(double * data, int index, int handle) {
+
+    // Get function pointer
+    void (*load_prim)(double *, int, int) =
+        trixi_function_pointers[TRIXI_FTPR_LOAD_PRIM];
+
+    // Call function
+    load_prim(data, index, handle);
+}
 
 
 /******************************************************************************************/

--- a/src/api.c
+++ b/src/api.c
@@ -554,26 +554,27 @@ int trixi_nvariables(int handle) {
 /** 
  * @anchor trixi_load_cell_averages_api_c
  *
- * @brief Return cell averaged values
+ * @brief Return cell averaged solution state
  *
- * Cell averaged values for each cell and each primitive variable are stored in a
- * contiguous array, where cell values for the first variable appear first and values for
- * the other variables subsequently (structure-of-arrays layout).
+ * Cell averaged values for the primitive variable at position index for each cell are
+ * stored in the given array `data`.
  *
  * The given array has to be of correct size and memory has to be allocated beforehand.
  *
  * @param[in]  handle  simulation handle
+ * @param[in]  index   index of variable
  * @param[out] data    cell averaged values for all cells and all primitive variables
  */
-void trixi_load_cell_averages(double * data, int handle) {
+void trixi_load_cell_averages(double * data, int index, int handle) {
 
     // Get function pointer
-    void (*load_cell_averages)(double *, int) =
+    void (*load_cell_averages)(double *, int, int) =
         trixi_function_pointers[TRIXI_FTPR_LOAD_CELL_AVERAGES];
 
     // Call function
-    load_cell_averages(data, handle);
+    load_cell_averages(data, index, handle);
 }
+
 
 
 

--- a/src/api.c
+++ b/src/api.c
@@ -17,6 +17,7 @@ enum {
     TRIXI_FPTR_NELEMENTS_GLOBAL,
     TRIXI_FPTR_NDOFS,
     TRIXI_FPTR_NDOFS_GLOBAL,
+    TRIXI_FPTR_NDOFS_ELEMENT,
     TRIXI_FTPR_NVARIABLES,
     TRIXI_FTPR_LOAD_CELL_AVERAGES,
     TRIXI_FTPR_LOAD_PRIM,
@@ -49,6 +50,7 @@ static const char* trixi_function_pointer_names[] = {
     [TRIXI_FPTR_NELEMENTS_GLOBAL]       = "trixi_nelements_global_cfptr",
     [TRIXI_FPTR_NDOFS]                  = "trixi_ndofs_cfptr",
     [TRIXI_FPTR_NDOFS_GLOBAL]           = "trixi_ndofs_global_cfptr",
+    [TRIXI_FPTR_NDOFS_ELEMENT]          = "trixi_ndofs_element_cfptr",
     [TRIXI_FTPR_NVARIABLES]             = "trixi_nvariables_cfptr",
     [TRIXI_FTPR_LOAD_CELL_AVERAGES]     = "trixi_load_cell_averages_cfptr",
     [TRIXI_FTPR_LOAD_PRIM]              = "trixi_load_prim_cfptr",
@@ -533,6 +535,23 @@ int trixi_ndofs_global(int handle) {
 
     // Call function
     return ndofs_global(handle);
+}
+
+
+/**
+ * @anchor trixi_ndofs_element_api_c
+ *
+ * @brief Return number of degrees of freedom per element (cell).
+ *
+ * @param[in]  handle  simulation handle
+ */
+int trixi_ndofs_element(int handle) {
+
+    // Get function pointer
+    int (*ndofs_element)(int) = trixi_function_pointers[TRIXI_FPTR_NDOFS_ELEMENT];
+
+    // Call function
+    return ndofs_element(handle);
 }
 
 

--- a/src/api.c
+++ b/src/api.c
@@ -15,6 +15,8 @@ enum {
     TRIXI_FTPR_NDIMS,
     TRIXI_FPTR_NELEMENTS,
     TRIXI_FPTR_NELEMENTS_GLOBAL,
+    TRIXI_FPTR_NDOFS,
+    TRIXI_FPTR_NDOFS_GLOBAL,
     TRIXI_FTPR_NVARIABLES,
     TRIXI_FTPR_LOAD_CELL_AVERAGES,
     TRIXI_FTPR_VERSION_LIBRARY,
@@ -44,6 +46,8 @@ static const char* trixi_function_pointer_names[] = {
     [TRIXI_FTPR_NDIMS]                  = "trixi_ndims_cfptr",
     [TRIXI_FPTR_NELEMENTS]              = "trixi_nelements_cfptr",
     [TRIXI_FPTR_NELEMENTS_GLOBAL]       = "trixi_nelements_global_cfptr",
+    [TRIXI_FPTR_NDOFS]                  = "trixi_ndofs_cfptr",
+    [TRIXI_FPTR_NDOFS_GLOBAL]           = "trixi_ndofs_global_cfptr",
     [TRIXI_FTPR_NVARIABLES]             = "trixi_nvariables_cfptr",
     [TRIXI_FTPR_LOAD_CELL_AVERAGES]     = "trixi_load_cell_averages_cfptr",
     [TRIXI_FTPR_VERSION_LIBRARY]        = "trixi_version_library_cfptr",
@@ -485,6 +489,48 @@ int trixi_nelements_global(int handle) {
 
     // Call function
     return nelements_global(handle);
+}
+
+
+/**
+ * @anchor trixi_ndofs_api_c
+ *
+ * @brief Return number of local degrees of freedom.
+ *
+ * These usually differ from the global count when doing parallel computations.
+ *
+ * @param[in]  handle  simulation handle
+ *
+ * @see trixi_ndofs_global_api_c
+ */
+int trixi_ndofs(int handle) {
+
+    // Get function pointer
+    int (*ndofs)(int) = trixi_function_pointers[TRIXI_FPTR_NDOFS];
+
+    // Call function
+    return ndofs(handle);
+}
+
+
+/**
+ * @anchor trixi_ndofs_global_api_c
+ *
+ * @brief Return number of global degrees of freedom.
+ *
+ * These usually differ from the local count when doing parallel computations.
+ *
+ * @param[in]  handle  simulation handle
+ *
+ * @see trixi_ndofs_api_c
+ */
+int trixi_ndofs_global(int handle) {
+
+    // Get function pointer
+    int (*ndofs_global)(int) = trixi_function_pointers[TRIXI_FPTR_NDOFS_GLOBAL];
+
+    // Call function
+    return ndofs_global(handle);
 }
 
 

--- a/src/api.f90
+++ b/src/api.f90
@@ -297,6 +297,16 @@ module LibTrixi
       integer(c_int), value, intent(in) :: handle
     end function
 
+    !! @anchor trixi_ndofs_element_api_c
+    !!
+    !! @brief Return number of degrees of freedom per element (cell).
+    !!
+    !! @param[in]  handle  simulation handle
+    integer(c_int) function trixi_ndofs_element(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int
+      integer(c_int), value, intent(in) :: handle
+    end function
+
     !>
     !! @fn LibTrixi::trixi_nvariables::trixi_nvariables(handle)
     !!

--- a/src/api.f90
+++ b/src/api.f90
@@ -337,6 +337,23 @@ module LibTrixi
       integer(c_int), value, intent(in) :: handle
     end subroutine
 
+    !>
+    !! @fn LibTrixi::trixi_load_prim::trixi_load_prim(data, index, handle)
+    !!
+    !! @brief Return primitive variable values
+    !!
+    !! @param[in]  handle  simulation handle
+    !! @param[in]  index   index of variable
+    !! @param[out] data    primitive variable values for all degrees of freedom
+    !!
+    !! @see @ref trixi_load_prim_api_c "trixi_load_prim (C API)"
+    subroutine trixi_load_prim(data, index, handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int, c_double
+      real(c_double), dimension(*), intent(in) :: data
+      integer(c_int), value, intent(in) :: index
+      integer(c_int), value, intent(in) :: handle
+    end subroutine
+
 
 
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/api.f90
+++ b/src/api.f90
@@ -311,17 +311,19 @@ module LibTrixi
     end function
 
     !>
-    !! @fn LibTrixi::trixi_load_cell_averages::trixi_load_cell_averages(data, handle)
+    !! @fn LibTrixi::trixi_load_cell_averages::trixi_load_cell_averages(data, index, handle)
     !!
     !! @brief Return cell averaged values
     !!
     !! @param[in]  handle  simulation handle
+    !! @param[in]  index   index of variable
     !! @param[out] data    cell averaged values for all cells and all variables
     !!
     !! @see @ref trixi_load_cell_averages_api_c "trixi_load_cell_averages (C API)"
-    subroutine trixi_load_cell_averages(data, handle) bind(c)
+    subroutine trixi_load_cell_averages(data, index, handle) bind(c)
       use, intrinsic :: iso_c_binding, only: c_int, c_double
       real(c_double), dimension(*), intent(in) :: data
+      integer(c_int), value, intent(in) :: index
       integer(c_int), value, intent(in) :: handle
     end subroutine
 

--- a/src/api.f90
+++ b/src/api.f90
@@ -272,6 +272,32 @@ module LibTrixi
     end function
 
     !>
+    !! @fn LibTrixi::trixi_ndofs::trixi_ndofs(handle)
+    !!
+    !! @brief Return number of local degrees of freedom
+    !!
+    !! @param[in]  handle  simulation handle
+    !!
+    !! @see @ref trixi_ndofs_api_c "trixi_ndofs (C API)"
+    integer(c_int) function trixi_ndofs(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int
+      integer(c_int), value, intent(in) :: handle
+    end function
+
+    !>
+    !! @fn LibTrixi::trixi_ndofs_global::trixi_ndofs_global(handle)
+    !!
+    !! @brief Return number of global degrees of freedom
+    !!
+    !! @param[in]  handle  simulation handle
+    !!
+    !! @see @ref trixi_ndofs_global_api_c "trixi_ndofs_global (C API)"
+    integer(c_int) function trixi_ndofs_global(handle) bind(c)
+      use, intrinsic :: iso_c_binding, only: c_int
+      integer(c_int), value, intent(in) :: handle
+    end function
+
+    !>
     !! @fn LibTrixi::trixi_nvariables::trixi_nvariables(handle)
     !!
     !! @brief Return number of (conservative) variables

--- a/src/api.f90
+++ b/src/api.f90
@@ -297,11 +297,14 @@ module LibTrixi
       integer(c_int), value, intent(in) :: handle
     end function
 
-    !! @anchor trixi_ndofs_element_api_c
+    !>
+    !! @fn LibTrixi::trixi_ndofs_element::trixi_ndofs_element(handle)
     !!
     !! @brief Return number of degrees of freedom per element (cell).
     !!
     !! @param[in]  handle  simulation handle
+    !!
+    !! @see @ref trixi_ndofs_element_api_c "trixi_ndofs_element (C API)"
     integer(c_int) function trixi_ndofs_element(handle) bind(c)
       use, intrinsic :: iso_c_binding, only: c_int
       integer(c_int), value, intent(in) :: handle

--- a/src/trixi.h
+++ b/src/trixi.h
@@ -30,6 +30,7 @@ int trixi_nelements(int handle);
 int trixi_nelements_global(int handle);
 int trixi_ndofs(int handle);
 int trixi_ndofs_global(int handle);
+int trixi_ndofs_element(int handle);
 int trixi_nvariables(int handle);
 double trixi_calculate_dt(int handle);
 void trixi_load_cell_averages(double * data, int index, int handle);

--- a/src/trixi.h
+++ b/src/trixi.h
@@ -28,6 +28,8 @@ void trixi_step(int handle);
 int trixi_ndims(int handle);
 int trixi_nelements(int handle);
 int trixi_nelements_global(int handle);
+int trixi_ndofs(int handle);
+int trixi_ndofs_global(int handle);
 int trixi_nvariables(int handle);
 double trixi_calculate_dt(int handle);
 void trixi_load_cell_averages(double * data, int handle);

--- a/src/trixi.h
+++ b/src/trixi.h
@@ -33,6 +33,7 @@ int trixi_ndofs_global(int handle);
 int trixi_nvariables(int handle);
 double trixi_calculate_dt(int handle);
 void trixi_load_cell_averages(double * data, int index, int handle);
+void trixi_load_prim(double * data, int index, int handle);
 
 // T8code
 #if !defined(T8_H) && !defined(T8_FOREST_GENERAL_H)

--- a/src/trixi.h
+++ b/src/trixi.h
@@ -32,7 +32,7 @@ int trixi_ndofs(int handle);
 int trixi_ndofs_global(int handle);
 int trixi_nvariables(int handle);
 double trixi_calculate_dt(int handle);
-void trixi_load_cell_averages(double * data, int handle);
+void trixi_load_cell_averages(double * data, int index, int handle);
 
 // T8code
 #if !defined(T8_H) && !defined(T8_FOREST_GENERAL_H)

--- a/test/c/simulation.cpp
+++ b/test/c/simulation.cpp
@@ -136,22 +136,11 @@ TEST(CInterfaceTest, SimulationRun) {
     trixi_load_prim(rho.data(), 1, handle);
     trixi_load_prim(energy.data(), 4, handle);
     // check memory boarders
-    if (nranks == 1) {
-        EXPECT_DOUBLE_EQ(rho[0],          1.0);
-        EXPECT_DOUBLE_EQ(rho[ndofs-1],    1.0);
-        EXPECT_DOUBLE_EQ(energy[0],       1.0e-5);
-        EXPECT_DOUBLE_EQ(energy[ndofs-1], 1.0e-5);
-    }
-    else if (nranks == 2) {
-        EXPECT_DOUBLE_EQ(rho[0],          1.0);
-        EXPECT_DOUBLE_EQ(rho[ndofs-1],    1.0);
-        EXPECT_DOUBLE_EQ(energy[0],       1.0e-5);
-        EXPECT_DOUBLE_EQ(energy[ndofs-1], 1.0e-5);
-    }
-    else {
-        FAIL() << "Test cannot be run with " << nranks << " ranks.";
-    }
-    
+    EXPECT_DOUBLE_EQ(rho[0],          1.0);
+    EXPECT_DOUBLE_EQ(rho[ndofs-1],    1.0);
+    EXPECT_DOUBLE_EQ(energy[0],       1.0e-5);
+    EXPECT_DOUBLE_EQ(energy[ndofs-1], 1.0e-5);
+
     // Finalize Trixi simulation
     trixi_finalize_simulation(handle);
 

--- a/test/c/simulation.cpp
+++ b/test/c/simulation.cpp
@@ -67,49 +67,54 @@ TEST(CInterfaceTest, SimulationRun) {
     EXPECT_EQ(nvariables, 4);
 
     // Check cell averaged values
-    int size = nelements * nvariables;
-    std::vector<double> cell_averages(size);
-    trixi_load_cell_averages(cell_averages.data(), handle);
+    std::vector<double> rho_averages(nelements);
+    std::vector<double> v1_averages(nelements);
+    std::vector<double> v2_averages(nelements);
+    std::vector<double> e_averages(nelements);
+    trixi_load_cell_averages(rho_averages.data(), 1, handle);
+    trixi_load_cell_averages(v1_averages.data(), 2, handle);
+    trixi_load_cell_averages(v2_averages.data(), 3, handle);
+    trixi_load_cell_averages(e_averages.data(), 4, handle);
     if (nranks == 1) {
         // check memory boarders (densities at the beginning, energies at the end)
-        EXPECT_DOUBLE_EQ(cell_averages[0],              1.0);
-        EXPECT_DOUBLE_EQ(cell_averages[size-1],         1.0e-5);
+        EXPECT_DOUBLE_EQ(rho_averages[0],         1.0);
+        EXPECT_DOUBLE_EQ(e_averages[nelements-1], 1.0e-5);
         // check values somewhere near the center (expect symmetries)
         // densities
-        EXPECT_NEAR(cell_averages[93],                  0.88263491354796, 1e-14);
-        EXPECT_NEAR(cell_averages[94],                  0.88263491354796, 1e-14);
-        EXPECT_NEAR(cell_averages[161],                 0.88263491354796, 1e-14);
-        EXPECT_NEAR(cell_averages[162],                 0.88263491354796, 1e-14);
+        EXPECT_NEAR(rho_averages[ 93],            0.88263491354796, 1e-14);
+        EXPECT_NEAR(rho_averages[ 94],            0.88263491354796, 1e-14);
+        EXPECT_NEAR(rho_averages[161],            0.88263491354796, 1e-14);
+        EXPECT_NEAR(rho_averages[162],            0.88263491354796, 1e-14);
         // velocities
-        EXPECT_NEAR(cell_averages[ 93+  nelements],    -0.14037267400591, 1e-14);
-        EXPECT_NEAR(cell_averages[ 94+2*nelements],    -0.14037267400591, 1e-14);
-        EXPECT_NEAR(cell_averages[161+2*nelements],     0.14037267400591, 1e-14);
-        EXPECT_NEAR(cell_averages[162+  nelements],     0.14037267400591, 1e-14);
+        EXPECT_NEAR(v1_averages[ 93],            -0.14037267400591, 1e-14);
+        EXPECT_NEAR(v2_averages[ 94],            -0.14037267400591, 1e-14);
+        EXPECT_NEAR(v2_averages[161],             0.14037267400591, 1e-14);
+        EXPECT_NEAR(v1_averages[162],             0.14037267400591, 1e-14);
     }
     else if (nranks == 2) {
         if (rank == 0) {
             // check memory boarders (densities at the beginning, energies at the end)
-            EXPECT_DOUBLE_EQ(cell_averages[0],          1.0);
-            EXPECT_DOUBLE_EQ(cell_averages[size-1],     1.0e-5);
+            EXPECT_DOUBLE_EQ(rho_averages[0],         1.0);
+            EXPECT_DOUBLE_EQ(e_averages[nelements-1], 1.0e-5);
             // check values somewhere near the center (expect symmetries)
             // densities
-            EXPECT_NEAR(cell_averages[93],              0.88263491354796, 1e-14);
-            EXPECT_NEAR(cell_averages[94],              0.88263491354796, 1e-14);
+            EXPECT_NEAR(rho_averages[93],             0.88263491354796, 1e-14);
+            EXPECT_NEAR(rho_averages[94],             0.88263491354796, 1e-14);
             // velocities
-            EXPECT_NEAR(cell_averages[93+  nelements], -0.14037267400591, 1e-14);
-            EXPECT_NEAR(cell_averages[94+2*nelements], -0.14037267400591, 1e-14);
+            EXPECT_NEAR(v1_averages[93],             -0.14037267400591, 1e-14);
+            EXPECT_NEAR(v2_averages[94],             -0.14037267400591, 1e-14);
         }
         else {
             // check memory boarders (densities at the beginning, energies at the end)
-            EXPECT_DOUBLE_EQ(cell_averages[0],          1.0);
-            EXPECT_DOUBLE_EQ(cell_averages[size-1],     1.0e-5);
+            EXPECT_DOUBLE_EQ(rho_averages[0],         1.0);
+            EXPECT_DOUBLE_EQ(e_averages[nelements-1], 1.0e-5);
             // check values somewhere near the center (expect symmetries)
             // densities
-            EXPECT_NEAR(cell_averages[33],              0.88263491354796, 1e-14);
-            EXPECT_NEAR(cell_averages[34],              0.88263491354796, 1e-14);
+            EXPECT_NEAR(rho_averages[33],             0.88263491354796, 1e-14);
+            EXPECT_NEAR(rho_averages[34],             0.88263491354796, 1e-14);
             // velocities
-            EXPECT_NEAR(cell_averages[33+2*nelements],  0.14037267400591, 1e-14);
-            EXPECT_NEAR(cell_averages[34+  nelements],  0.14037267400591, 1e-14);
+            EXPECT_NEAR(v2_averages[33],              0.14037267400591, 1e-14);
+            EXPECT_NEAR(v1_averages[34],              0.14037267400591, 1e-14);
         }
     }
     else {

--- a/test/c/simulation.cpp
+++ b/test/c/simulation.cpp
@@ -135,15 +135,18 @@ TEST(CInterfaceTest, SimulationRun) {
     std::vector<double> energy(ndofs);
     trixi_load_prim(rho.data(), 1, handle);
     trixi_load_prim(energy.data(), 4, handle);
+    // check memory boarders
     if (nranks == 1) {
-        // check memory boarders (densities at the beginning, energies at the end)
-        EXPECT_DOUBLE_EQ(rho[0],         1.0);
-        EXPECT_DOUBLE_EQ(rho[ndofs-1],         1.0);
-        EXPECT_DOUBLE_EQ(energy[0], 1.0e-5);
+        EXPECT_DOUBLE_EQ(rho[0],          1.0);
+        EXPECT_DOUBLE_EQ(rho[ndofs-1],    1.0);
+        EXPECT_DOUBLE_EQ(energy[0],       1.0e-5);
         EXPECT_DOUBLE_EQ(energy[ndofs-1], 1.0e-5);
     }
     else if (nranks == 2) {
-        
+        EXPECT_DOUBLE_EQ(rho[0],          1.0);
+        EXPECT_DOUBLE_EQ(rho[ndofs-1],    1.0);
+        EXPECT_DOUBLE_EQ(energy[0],       1.0e-5);
+        EXPECT_DOUBLE_EQ(energy[ndofs-1], 1.0e-5);
     }
     else {
         FAIL() << "Test cannot be run with " << nranks << " ranks.";

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -80,6 +80,7 @@ module simulationRun_suite
     call check(error, data(1),    1.0_dp)
     call check(error, data(94),   0.99833232379996562_dp)
     call check(error, data(size), 1.0_dp)
+    deallocate(data)
 
     ! Check primitive variable values
     size = ndofs
@@ -88,6 +89,7 @@ module simulationRun_suite
     call check(error, data(1),    1.0_dp)
     call check(error, data(3200), 0.99833232379996562_dp)
     call check(error, data(size), 1.0_dp)
+    deallocate(data)
 
     ! Finalize Trixi simulation
     call trixi_finalize_simulation(handle)

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -68,7 +68,7 @@ module simulationRun_suite
     call trixi_load_cell_averages(data, 1, handle)
     call check(error, data(1), 1.0_dp)
     call check(error, data(94), 0.99833232379996562_dp)
-    call check(error, data(size), 1e-5_dp)
+    call check(error, data(size), 1.0_dp)
 
     ! Finalize Trixi simulation
     call trixi_finalize_simulation(handle)

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -58,6 +58,16 @@ module simulationRun_suite
     nelements_global = trixi_nelements_global(handle)
     call check(error, nelements_global, 256)
 
+    ! Check number of dofs
+    ndofs_element = trixi_ndofs_element(handle)
+    call check(error, ndofs_element, 16)
+
+    ndofs = trixi_ndofs(handle)
+    call check(error, ndofs, nelements * ndofs_element)
+
+    ndofs_global = trixi_ndofs_global(handle)
+    call check(error, ndofs_global, nelements_global * ndofs_element)
+
     ! Check number of variables
     nvariables = trixi_nvariables(handle)
     call check(error, nvariables, 4)

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -67,7 +67,7 @@ module simulationRun_suite
     allocate(data(size))
     call trixi_load_cell_averages(data, 1, handle)
     call check(error, data(1), 1.0_dp)
-    call check(error, data(94), 0.88263491354796_dp)
+    call check(error, data(94), 0.99833232379996562_dp)
     call check(error, data(size), 1e-5_dp)
 
     ! Finalize Trixi simulation

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -22,7 +22,8 @@ module simulationRun_suite
 
   subroutine test_simulationRun(error)
     type(error_type), allocatable, intent(out) :: error
-    integer :: handle, ndims, nelements, nelements_global, nvariables, size
+    integer :: handle, ndims, nelements, nelements_global, nvariables, ndofs_global, &
+               ndofs_element, ndofs, size
     logical :: finished_status
     ! dp as defined in test-drive
     integer, parameter :: dp = selected_real_kind(15)
@@ -76,6 +77,14 @@ module simulationRun_suite
     size = nelements
     allocate(data(size))
     call trixi_load_cell_averages(data, 1, handle)
+    call check(error, data(1), 1.0_dp)
+    call check(error, data(94), 0.99833232379996562_dp)
+    call check(error, data(size), 1.0_dp)
+
+    ! Check primitive variable values
+    size = ndofs
+    allocate(data(size))
+    call trixi_load_prim(data, 1, handle)
     call check(error, data(1), 1.0_dp)
     call check(error, data(94), 0.99833232379996562_dp)
     call check(error, data(size), 1.0_dp)

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -61,7 +61,7 @@ module simulationRun_suite
 
     ! Check number of dofs
     ndofs_element = trixi_ndofs_element(handle)
-    call check(error, ndofs_element, 16)
+    call check(error, ndofs_element, 25)
 
     ndofs = trixi_ndofs(handle)
     call check(error, ndofs, nelements * ndofs_element)
@@ -77,16 +77,16 @@ module simulationRun_suite
     size = nelements
     allocate(data(size))
     call trixi_load_cell_averages(data, 1, handle)
-    call check(error, data(1), 1.0_dp)
-    call check(error, data(94), 0.99833232379996562_dp)
+    call check(error, data(1),    1.0_dp)
+    call check(error, data(94),   0.99833232379996562_dp)
     call check(error, data(size), 1.0_dp)
 
     ! Check primitive variable values
     size = ndofs
     allocate(data(size))
     call trixi_load_prim(data, 1, handle)
-    call check(error, data(1), 1.0_dp)
-    call check(error, data(94), 0.99833232379996562_dp)
+    call check(error, data(1),    1.0_dp)
+    call check(error, data(3200), 0.99833232379996562_dp)
     call check(error, data(size), 1.0_dp)
 
     ! Finalize Trixi simulation

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -63,13 +63,13 @@ module simulationRun_suite
     call check(error, nvariables, 4)
 
     ! Check cell averaged values
-    size = nelements*nvariables
+    size = nelements
     allocate(data(size))
-    call trixi_load_cell_averages(data, handle)
+    call trixi_load_cell_averages(data, 1, handle)
     call check(error, data(1), 1.0_dp)
-    call check(error, data(929), 2.6605289164377273_dp)
+    call check(error, data(94), 0.88263491354796_dp)
     call check(error, data(size), 1e-5_dp)
-    
+
     ! Finalize Trixi simulation
     call trixi_finalize_simulation(handle)
     

--- a/test/fortran/simulationRun_suite.f90
+++ b/test/fortran/simulationRun_suite.f90
@@ -87,7 +87,7 @@ module simulationRun_suite
     allocate(data(size))
     call trixi_load_prim(data, 1, handle)
     call check(error, data(1),    1.0_dp)
-    call check(error, data(3200), 0.99833232379996562_dp)
+    call check(error, data(3200), 1.0_dp)
     call check(error, data(size), 1.0_dp)
     deallocate(data)
 


### PR DESCRIPTION
This is to demonstrate how an external function could be called to evaluate source terms.

Issues:
- Path to shared object is currently hard-coded.
- Global buffer variable in libelixir to prevent subsequent allocations in `source_term_callback`

Some rough timing results:

<details>
<summary>Timing libtrixi</summary>

```
────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 2.0  Time steps: 229 (accepted), 229 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────


*** Trixi controller ***   Finalize Trixi simulation
 ────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              2.39s /  19.5%            129MiB /  14.2%

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 I/O                            5    200ms   43.0%  40.1ms   10.6MiB   57.4%  2.11MiB
   save solution                4    124ms   26.6%  31.0ms   10.3MiB   56.1%  2.59MiB
   ~I/O~                        5   76.3ms   16.4%  15.3ms    230KiB    1.2%  46.1KiB
   get element variables        4   1.52μs    0.0%   380ns     0.00B    0.0%    0.00B
   save mesh                    4    501ns    0.0%   125ns     0.00B    0.0%    0.00B
   get node variables           4   88.0ns    0.0%  22.0ns     0.00B    0.0%    0.00B
 rhs!                       1.15k    174ms   37.3%   152μs   5.14KiB    0.0%    4.59B
   source terms             1.15k   80.7ms   17.3%  70.4μs     0.00B    0.0%    0.00B
   volume integral          1.15k   45.9ms    9.8%  40.0μs     0.00B    0.0%    0.00B
   interface flux           1.15k   29.7ms    6.4%  25.9μs     0.00B    0.0%    0.00B
   surface integral         1.15k   10.8ms    2.3%  9.44μs     0.00B    0.0%    0.00B
   Jacobian                 1.15k   4.16ms    0.9%  3.63μs     0.00B    0.0%    0.00B
   reset ∂u/∂t              1.15k   2.20ms    0.5%  1.92μs     0.00B    0.0%    0.00B
   ~rhs!~                   1.15k    523μs    0.1%   457ns   5.14KiB    0.0%    4.59B
   boundary flux            1.15k   21.4μs    0.0%  18.7ns     0.00B    0.0%    0.00B
 analyze solution               4   87.2ms   18.7%  21.8ms   7.85MiB   42.6%  1.96MiB
 calculate dt                 230   4.44ms    1.0%  19.3μs     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────
```
</details>


<details>
<summary>Timing Trixi.jl</summary>

```
────────────────────────────────────────────────────────────────────────────────────
              Trixi.jl                      Time                    Allocations
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              164ms /  94.0%           2.00MiB /  90.6%

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 rhs!                       1.15k    144ms   93.2%   126μs   5.14KiB    0.3%    4.59B
   source terms             1.15k   59.7ms   38.7%  52.1μs     0.00B    0.0%    0.00B
   volume integral          1.15k   41.5ms   26.9%  36.2μs     0.00B    0.0%    0.00B
   interface flux           1.15k   26.6ms   17.3%  23.2μs     0.00B    0.0%    0.00B
   surface integral         1.15k   9.68ms    6.3%  8.44μs     0.00B    0.0%    0.00B
   Jacobian                 1.15k   3.82ms    2.5%  3.34μs     0.00B    0.0%    0.00B
   reset ∂u/∂t              1.15k   1.99ms    1.3%  1.73μs     0.00B    0.0%    0.00B
   ~rhs!~                   1.15k    498μs    0.3%   434ns   5.14KiB    0.3%    4.59B
   boundary flux            1.15k   28.8μs    0.0%  25.2ns     0.00B    0.0%    0.00B
 I/O                            5   4.82ms    3.1%   964μs   1.56MiB   85.9%   319KiB
   save solution                4   4.31ms    2.8%  1.08ms   1.55MiB   85.4%   397KiB
   ~I/O~                        5    507μs    0.3%   101μs   8.83KiB    0.5%  1.77KiB
   get element variables        4    765ns    0.0%   191ns     0.00B    0.0%    0.00B
   save mesh                    4    488ns    0.0%   122ns     0.00B    0.0%    0.00B
   get node variables           4    342ns    0.0%  85.5ns     0.00B    0.0%    0.00B
 calculate dt                 230   4.04ms    2.6%  17.6μs     0.00B    0.0%    0.00B
 analyze solution               4   1.59ms    1.0%   396μs    258KiB   13.9%  64.5KiB
 ────────────────────────────────────────────────────────────────────────────────────
```
</details>
