### PR TITLE
Filter dependabot commits in release changelog

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -32,3 +32,4 @@ jobs:
           ssh: ${{ secrets.DOCUMENTER_KEY }}
           subdir: LibTrixi.jl
           tag_prefix: NO_PREFIX
+          changelog_ignore: dependencies


### PR DESCRIPTION
TagBot can be instructed to leave out certain commit messages when compiling the changelog based on labels.

I think we do not need all the "bump x" messages.

CompatHelper messages, however, will not be captured as they do not have a label.