### PR TITLE
Use main julia version for PackageCompiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,13 @@ jobs:
         test_type:
           - regular
           - coverage
+          - package-compiler
         arch:
           - x64
         julia_version:
           - '1.10'
         t8code_version:
           - '3.0.0'
-        include:
-          - os: ubuntu-latest
-            test_type: package-compiler
-            arch: x64
-            julia_version: '1.9.3'  # 1.9.4: missing nghttp2 symbols in libcurl
-            t8code_version: '3.0.0'
     env:
       # Necessary for HDF5 to play nice with Julia
       LD_PRELOAD: /lib/x86_64-linux-gnu/libcurl.so.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
         run: |
           cd build
           make -j2
+          du -hL ./prefix-pc/lib/libtrixi.so
 
       - name: Test external CMake project
         if: ${{ matrix.test_type == 'regular' }}


### PR DESCRIPTION
This fixes the long lasting package compiler issue. Not because of julia versions, but because of a new package compiler release. In particular this PR https://github.com/JuliaLang/PackageCompiler.jl/pull/987 and this line https://github.com/JuliaLang/PackageCompiler.jl/pull/987/files#diff-ec15186e80d0dd77de71866cee17c75857c4eb441c51df407b96f680c11cf847 seem relevant. 

However, I noticed that the resulting shared object is now large (~700 MB) regardless of whether `filter_stdlibs` is set to true or false.

If we merge this and thereby drop julia 1.9, this resolves #152 #213
