### PR TITLE
(Temporary) workaround for failing `HDF5_jll` precomilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
               --t8code-library ../t8code-local/prefix/lib/libt8.so \
               --julia-depot ~/.julia \
               --force
-        continue-on-error: true
+        continue-on-error: true # HDF5_jll hotfix (see https://github.com/trixi-framework/libtrixi/pull/241)
 
       - name: Configure (test_type == 'package-compiler')
         if: ${{ matrix.test_type == 'package-compiler' }}


### PR DESCRIPTION
Given the fact that `HDF5_jll` is not used for our actual tests, we can ignore the failing precompilation in the setup steps. This would allow us to have our CI running again until there is a proper fix for #178, maybe via https://github.com/JuliaPackaging/Yggdrasil/pull/10977.