### PR TITLE
Add  Trixi version 0.13

### DIFF
--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -13,7 +13,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 MPI = "0.20.13"
 OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
-Trixi = "0.9.12, 0.10, 0.11, 0.12"
+Trixi = "0.9.12, 0.10, 0.11, 0.12, 0.13"
 julia = "1.8"
 
 [preferences.OrdinaryDiffEq]

--- a/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
+++ b/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
@@ -41,7 +41,7 @@ function init_simstate()
     initial_condition = initial_condition_sedov_blast_wave
 
     # Get the DG approximation space
-    surface_flux = FluxLaxFriedrichs(max_abs_speed = max_abs_speed_naive)
+    surface_flux = FluxLaxFriedrichs(max_abs_speed_naive)
     volume_flux = flux_ranocha
     polydeg = 4
     basis = LobattoLegendreBasis(polydeg)

--- a/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
+++ b/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
@@ -41,7 +41,7 @@ function init_simstate()
     initial_condition = initial_condition_sedov_blast_wave
 
     # Get the DG approximation space
-    surface_flux = flux_lax_friedrichs
+    surface_flux = FluxLaxFriedrichs(max_abs_speed = max_abs_speed_naive)
     volume_flux = flux_ranocha
     polydeg = 4
     basis = LobattoLegendreBasis(polydeg)

--- a/LibTrixi.jl/test/Project.toml
+++ b/LibTrixi.jl/test/Project.toml
@@ -5,7 +5,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 OrdinaryDiffEq = "6.53.2"
-Trixi = "0.9.12, 0.10, 0.11, 0.12"
+Trixi = "0.9.12, 0.10, 0.11, 0.12, 0.13"
 
 [preferences.OrdinaryDiffEq]
 PrecompileAutoSpecialize = false


### PR DESCRIPTION
Closes #245 
Closes #246

Explicitly set wave speed for Local Lax-Friedrichs to `max_abs_speed_naive` as it used to be.
Xref: https://github.com/trixi-framework/Trixi.jl/pull/2458