### PR TITLE
Fix package compiler and regular builds

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
       - name: Check spelling
-        uses: crate-ci/typos@v1.34.0
+        uses: crate-ci/typos@v1.35.5

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -7,12 +7,14 @@ version = "0.1.6-pre"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 MPI = "0.20.13"
 OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
+PreallocationTools = "< 0.4.30"
 Trixi = "0.9.12, 0.10, 0.11, 0.12, 0.13"
 julia = "1.8"
 

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -13,7 +13,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 MPI = "0.20.13"
 OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
-Trixi = "0.9.12, 0.10, 0.11, 0.12"
+Trixi = "0.9.12, 0.10, 0.11, 0.12, 0.13"
 julia = "1.8"
 
 [preferences.OrdinaryDiffEq]

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -7,14 +7,12 @@ version = "0.1.6-pre"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 MPI = "0.20.13"
 OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
-PreallocationTools = "< 0.4.30"
 Trixi = "0.9.12, 0.10, 0.11, 0.12, 0.13"
 julia = "1.8"
 

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -7,7 +7,6 @@ version = "0.1.6-pre"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.6-pre"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]

--- a/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
+++ b/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
@@ -41,7 +41,7 @@ function init_simstate()
     initial_condition = initial_condition_sedov_blast_wave
 
     # Get the DG approximation space
-    surface_flux = flux_lax_friedrichs
+    surface_flux = FluxLaxFriedrichs(max_abs_speed_naive)
     volume_flux = flux_ranocha
     polydeg = 4
     basis = LobattoLegendreBasis(polydeg)

--- a/LibTrixi.jl/examples/libelixir_t8code3d_euler_baroclinic_instability.jl
+++ b/LibTrixi.jl/examples/libelixir_t8code3d_euler_baroclinic_instability.jl
@@ -297,7 +297,7 @@ function init_simstate()
                             save_solution)
 
     # use a Runge-Kutta method with automatic (error based) time step size control
-    integrator = init(ode, RDPK3SpFSAL49(thread = OrdinaryDiffEq.False());
+    integrator = init(ode, RDPK3SpFSAL49(thread = Trixi.False());
                       abstol = 1.0e-6, reltol = 1.0e-6,
                       ode_default_options()..., callback = callbacks, maxiters=1e7);
 

--- a/LibTrixi.jl/examples/libelixir_t8code3d_euler_tracer.jl
+++ b/LibTrixi.jl/examples/libelixir_t8code3d_euler_tracer.jl
@@ -113,7 +113,7 @@ function init_simstate()
                             save_solution)
 
     # use a Runge-Kutta method with automatic (error based) time step size control
-    integrator = init(ode, RDPK3SpFSAL49(thread = OrdinaryDiffEq.False());
+    integrator = init(ode, RDPK3SpFSAL49(thread = Trixi.False());
                       abstol = 1.0e-6, reltol = 1.0e-6,
                       ode_default_options()..., callback = callbacks, maxiters=1e7);
 

--- a/LibTrixi.jl/lib/Project.toml
+++ b/LibTrixi.jl/lib/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]

--- a/LibTrixi.jl/lib/Project.toml
+++ b/LibTrixi.jl/lib/Project.toml
@@ -5,5 +5,5 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 PackageCompiler = "2.1.9"
-PreallocationTools = "0.4.29"
+PreallocationTools = "< 0.4.30"
 TOML = "1"

--- a/LibTrixi.jl/lib/Project.toml
+++ b/LibTrixi.jl/lib/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 PackageCompiler = "2.1.9"
+PreallocationTools = "0.4.29"
 TOML = "1"

--- a/LibTrixi.jl/lib/Project.toml
+++ b/LibTrixi.jl/lib/Project.toml
@@ -1,9 +1,7 @@
 [deps]
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 PackageCompiler = "2.1.9"
-PreallocationTools = "< 0.4.30"
 TOML = "1"

--- a/LibTrixi.jl/lib/Project.toml
+++ b/LibTrixi.jl/lib/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]

--- a/LibTrixi.jl/lib/build.jl
+++ b/LibTrixi.jl/lib/build.jl
@@ -43,7 +43,7 @@ lib_name = "trixi"
 incremental = false
 
 # Do not include stdlibs which are not needed
-filter_stdlibs = true
+filter_stdlibs = false
 
 # Overwrite existing files/folders at `dest_dir`
 force = true

--- a/LibTrixi.jl/lib/build.jl
+++ b/LibTrixi.jl/lib/build.jl
@@ -43,7 +43,7 @@ lib_name = "trixi"
 incremental = false
 
 # Do not include stdlibs which are not needed
-filter_stdlibs = false
+filter_stdlibs = true
 
 # Overwrite existing files/folders at `dest_dir`
 force = true

--- a/LibTrixi.jl/test/Project.toml
+++ b/LibTrixi.jl/test/Project.toml
@@ -5,7 +5,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 OrdinaryDiffEq = "6.53.2"
-Trixi = "0.9.12, 0.10, 0.11, 0.12"
+Trixi = "0.9.12, 0.10, 0.11, 0.12, 0.13"
 
 [preferences.OrdinaryDiffEq]
 PrecompileAutoSpecialize = false


### PR DESCRIPTION
~~Add `PreallocationTools = "< 0.4.30"` compat.~~

Use `filter_stdlibs = false` (thanks to @vchuravy )
(we found in #216 that the resulting shared object is large anyways)
Resolves #253 

Use `Trixi.False() ` instead of `OrdinaryDiffEq.False()`.