### PR TITLE
OrdinaryDiffEq updates

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v6
       - name: Check spelling
-        uses: crate-ci/typos@v1.42.1
+        uses: crate-ci/typos@v1.43.3

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -13,7 +13,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 MPI = "0.20.13"
 OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
-Trixi = "0.11.12, 0.12, 0.13, 0.14, 0.15"
+Trixi = "0.11.12, 0.12, 0.13, 0.14"
 julia = "1.8"
 
 [preferences.OrdinaryDiffEq]

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -5,23 +5,13 @@ authors = ["Michael Schlottke-Lakemper <michael@sloede.com>", "Benedict Geihe <b
 
 [deps]
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 MPI = "0.20.13"
-OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
+SciMLBase = "2.33.0"
 Trixi = "0.11.12, 0.12, 0.13, 0.14"
 julia = "1.8"
-
-[preferences.OrdinaryDiffEq]
-PrecompileAutoSpecialize = false
-PrecompileAutoSwitch = false
-PrecompileDefaultSpecialize = true
-PrecompileFunctionWrapperSpecialize = false
-PrecompileLowStorage = true
-PrecompileNoSpecialize = false
-PrecompileNonStiff = true
-PrecompileStiff = false

--- a/LibTrixi.jl/Project.toml
+++ b/LibTrixi.jl/Project.toml
@@ -13,7 +13,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 MPI = "0.20.13"
 OrdinaryDiffEq = "6.53.2"
 Pkg = "1.8"
-Trixi = "0.11.12, 0.12, 0.13, 0.14"
+Trixi = "0.11.12, 0.12, 0.13, 0.14, 0.15"
 julia = "1.8"
 
 [preferences.OrdinaryDiffEq]

--- a/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
+++ b/LibTrixi.jl/examples/libelixir_p4est2d_euler_sedov.jl
@@ -1,6 +1,6 @@
 using LibTrixi
 using Trixi
-using OrdinaryDiffEq
+using OrdinaryDiffEqLowStorageRK
 
 # The function to create the simulation state needs to be named `init_simstate`
 function init_simstate()

--- a/LibTrixi.jl/examples/libelixir_t8code2d_euler_tracer_amr.jl
+++ b/LibTrixi.jl/examples/libelixir_t8code2d_euler_tracer_amr.jl
@@ -1,5 +1,5 @@
 using LibTrixi
-using OrdinaryDiffEq
+using OrdinaryDiffEqLowStorageRK
 using Trixi
 
 # The function to create the simulation state needs to be named `init_simstate`

--- a/LibTrixi.jl/examples/libelixir_t8code3d_euler_baroclinic_instability.jl
+++ b/LibTrixi.jl/examples/libelixir_t8code3d_euler_baroclinic_instability.jl
@@ -9,7 +9,7 @@
 #   A proposed baroclinic wave test case for deep- and shallow-atmosphere dynamical cores
 #   https://doi.org/10.1002/qj.2241
 
-using OrdinaryDiffEq
+using OrdinaryDiffEqLowStorageRK
 using Trixi
 using LinearAlgebra
 using LibTrixi

--- a/LibTrixi.jl/examples/libelixir_t8code3d_euler_tracer.jl
+++ b/LibTrixi.jl/examples/libelixir_t8code3d_euler_tracer.jl
@@ -4,7 +4,7 @@
 # Note that this libelixir is based on an elixir by Erik Faulhaber for Trixi.jl
 # Source: https://github.com/trixi-framework/Trixi.jl/blob/main/examples/p4est_3d_dgsem/elixir_euler_circular_wind_nonconforming.jl
 
-using OrdinaryDiffEq
+using OrdinaryDiffEqLowStorageRK
 using Trixi
 using LinearAlgebra
 using LibTrixi

--- a/LibTrixi.jl/examples/libelixir_tree1d_advection_basic.jl
+++ b/LibTrixi.jl/examples/libelixir_tree1d_advection_basic.jl
@@ -1,6 +1,6 @@
 using LibTrixi
 using Trixi
-using OrdinaryDiffEq
+using OrdinaryDiffEqLowStorageRK
 
 # The function to create the simulation state needs to be named `init_simstate`
 function init_simstate()

--- a/LibTrixi.jl/src/LibTrixi.jl
+++ b/LibTrixi.jl/src/LibTrixi.jl
@@ -1,6 +1,6 @@
 module LibTrixi
 
-using OrdinaryDiffEq: OrdinaryDiffEq, step!, check_error, DiscreteCallback
+using SciMLBase: step!, check_error, successful_retcode, DiscreteCallback
 using Trixi: Trixi, summary_callback, mesh_equations_solver_cache, ndims, nelements,
              nelementsglobal, ndofs, ndofsglobal, nvariables, nnodes, wrap_array,
              eachelement, cons2prim, get_node_vars, eachnode

--- a/LibTrixi.jl/src/api_jl.jl
+++ b/LibTrixi.jl/src/api_jl.jl
@@ -30,7 +30,7 @@ function trixi_step_jl(simstate)
 
     ret = check_error(simstate.integrator)
 
-    if ret != :Success
+    if !successful_retcode(ret)
         error("integrator failed to perform time step, return code: ", ret)
     end
 

--- a/LibTrixi.jl/test/Project.toml
+++ b/LibTrixi.jl/test/Project.toml
@@ -5,7 +5,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 OrdinaryDiffEq = "6.53.2"
-Trixi = "0.11.12, 0.12, 0.13"
+Trixi = "0.11.12, 0.12, 0.13, 0.14"
 
 [preferences.OrdinaryDiffEq]
 PrecompileAutoSpecialize = false

--- a/LibTrixi.jl/test/Project.toml
+++ b/LibTrixi.jl/test/Project.toml
@@ -1,18 +1,8 @@
 [deps]
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
-OrdinaryDiffEq = "6.53.2"
+OrdinaryDiffEqLowStorageRK = "1"
 Trixi = "0.11.12, 0.12, 0.13, 0.14"
-
-[preferences.OrdinaryDiffEq]
-PrecompileAutoSpecialize = false
-PrecompileAutoSwitch = false
-PrecompileDefaultSpecialize = true
-PrecompileFunctionWrapperSpecialize = false
-PrecompileLowStorage = true
-PrecompileNoSpecialize = false
-PrecompileNonStiff = true
-PrecompileStiff = false

--- a/LibTrixi.jl/test/Project.toml
+++ b/LibTrixi.jl/test/Project.toml
@@ -5,7 +5,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 OrdinaryDiffEq = "6.53.2"
-Trixi = "0.11.12, 0.12, 0.13, 0.14, 0.15"
+Trixi = "0.11.12, 0.12, 0.13, 0.14"
 
 [preferences.OrdinaryDiffEq]
 PrecompileAutoSpecialize = false

--- a/LibTrixi.jl/test/Project.toml
+++ b/LibTrixi.jl/test/Project.toml
@@ -5,7 +5,7 @@ Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
 OrdinaryDiffEq = "6.53.2"
-Trixi = "0.11.12, 0.12, 0.13, 0.14"
+Trixi = "0.11.12, 0.12, 0.13, 0.14, 0.15"
 
 [preferences.OrdinaryDiffEq]
 PrecompileAutoSpecialize = false

--- a/utils/libtrixi-init-julia
+++ b/utils/libtrixi-init-julia
@@ -339,12 +339,12 @@ echo
 # Rationale: By first installing Trixi.jl, we ensure that we use its latest version,
 # even if it does not play nicely with the latest version of OrdinaryDiffEq.jl.
 # xref: https://github.com/trixi-framework/libtrixi/issues/190
-echo "Install Trixi.jl and OrdinaryDiffEq.jl..."
+echo "Install Trixi.jl and OrdinaryDiffEqLowStorageRK.jl..."
 JULIA_DEPOT_PATH="$julia_depot" JULIA_PKG_PRECOMPILE_AUTO=0 \
     $julia_exec --project=. \
     -e "
 using Pkg
-Pkg.add([\"Trixi\", \"OrdinaryDiffEq\"])
+Pkg.add([\"Trixi\", \"OrdinaryDiffEqLowStorageRK\"])
 "
 [ $? -eq 0 ] || die "could not install dependencies"
 echo


### PR DESCRIPTION
This PR originates from: https://github.com/trixi-framework/libtrixi/actions/runs/21808243190/job/62915273766#step:19:211

According to the docs (https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.ReturnCode) the return code has be checked for success differently, and this is what I did.

I am not sure which version actually introduced the change which made the old check fail, nor do I know which version introduced support for the new check. 
Instead, I decided to move to the split OrdinaryDiffEq packages, which I wanted to do at some point anyway.

Doing so, I realized we actually do not need OrdinaryDiffEq in LibTrixi.jl itself (just like with Trixi.jl).

Remaining questions @sloede 
1. Was there a reason to include OrdinaryDiffEq in LibTrixi.jl, which I do not remember?
2. Are the precompilation setting https://github.com/trixi-framework/libtrixi/blob/f5fffee06990fe008cf00fd2fc5214798974c478/LibTrixi.jl/test/Project.toml#L10 obsolete when using OrdinaryDiffEqLowStorageRK only?